### PR TITLE
Fix HEAD request handling in journal views

### DIFF
--- a/journal/views/post.py
+++ b/journal/views/post.py
@@ -270,7 +270,7 @@ def post_compose(request: AuthedHttpRequest):
     return HttpResponseRedirect(get_safe_referer_url(request, "/"))
 
 
-@require_http_methods(["GET"])
+@require_http_methods(["GET", "HEAD"])
 def post_view(request, handle: str, post_pk: int):
     if request.headers.get("HTTP_ACCEPT", "").endswith("json"):
         raise BadRequest("JSON not supported yet")
@@ -291,6 +291,8 @@ def post_view(request, handle: str, post_pk: int):
         domain = h[1]
     if owner.username != username or owner.domain_name != domain:
         raise Http404("Post not available")
+    if request.method == "HEAD":
+        return HttpResponse()
     match _can_view_post(post, owner, viewer):
         case 1:
             return render(request, "single_post.html", {"post": post, "owner": owner})

--- a/journal/views/profile.py
+++ b/journal/views/profile.py
@@ -180,10 +180,12 @@ def profile(request: AuthedHttpRequest, user_name):
     )
 
 
-@require_http_methods(["GET"])
+@require_http_methods(["GET", "HEAD"])
 @login_required
 @target_identity_required
 def user_calendar_data(request, user_name):
+    if request.method == "HEAD":
+        return HttpResponse()
     target = request.target_identity
     max_visiblity = max_visiblity_to_user(request.user, target)
     calendar_data = target.shelf_manager.get_calendar_data(max_visiblity)
@@ -196,11 +198,13 @@ def user_calendar_data(request, user_name):
     )
 
 
-@require_http_methods(["GET"])
+@require_http_methods(["GET", "HEAD"])
 def profile_collection_items(request: AuthedHttpRequest, collection_uuid):
     collection = get_object_or_404(Collection, uid=get_uuid_or_404(collection_uuid))
     if not collection.is_visible_to(request.user):
         # raise PermissionDenied(_("Insufficient permission"))
+        return HttpResponse()
+    if request.method == "HEAD":
         return HttpResponse()
 
     items = []

--- a/journal/views/review.py
+++ b/journal/views/review.py
@@ -29,7 +29,7 @@ from ..models.renderers import (
 from .common import render_list
 
 
-@require_http_methods(["GET"])
+@require_http_methods(["GET", "HEAD"])
 def review_retrieve(request, review_uuid):
     # piece = get_object_or_404(Review, uid=get_uuid_or_404(review_uuid))
     piece = Review.get_by_url(review_uuid)
@@ -37,6 +37,8 @@ def review_retrieve(request, review_uuid):
         raise Http404(_("Content not found"))
     if not piece.is_visible_to(request.user):
         raise PermissionDenied(_("Insufficient permission"))
+    if request.method == "HEAD":
+        return HttpResponse()
     return render(request, "review.html", {"review": piece})
 
 


### PR DESCRIPTION
## Summary
- Allow HEAD requests on journal views (`post_view`, `review_retrieve`, `user_calendar_data`, `profile_collection_items`) to avoid "Method Not Allowed (HEAD)" errors
- Return empty `HttpResponse()` early for HEAD requests after validation, skipping expensive template rendering

## Test plan
- [ ] Verify `HEAD /@user/posts/<id>/` returns 200 instead of 405
- [ ] Verify `HEAD /review/<uuid>/` returns 200
- [ ] Verify GET requests still render normally