### PR TITLE
Fix N+1 query issues from Sentry performance data

### DIFF
--- a/catalog/apis.py
+++ b/catalog/apis.py
@@ -10,6 +10,7 @@ from ninja.pagination import paginate
 from common.api import PageNumberPagination, RedirectedResult, Result, api
 from journal.models.mark import Mark
 from journal.models.rating import Rating
+from journal.models.tag import Tag
 
 from .common import SiteManager
 from .models import (
@@ -116,6 +117,7 @@ def search_item(
         exclude_categories=exclude_categories,
     )
     Rating.attach_to_items(items)
+    Tag.attach_to_items(items)
     if request.user.is_authenticated:
         Mark.attach_to_items(request.user.identity, items, request.user)
     return 200, {"data": items, "pages": num_pages, "count": count}

--- a/catalog/search/utils.py
+++ b/catalog/search/utils.py
@@ -51,6 +51,7 @@ def query_index(
     items = []
     urls = []
     search_items = r.items
+    prefetch_related_objects(search_items, "external_resources")
     editions = [item for item in search_items if isinstance(item, Edition)]
     if editions:
         prefetch_related_objects(editions, "works")

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -200,18 +200,18 @@ def _prefetch_comments(comments_list: list["Comment"]):
 
     # Batch-fetch ShelfMembers for all (owner, item) pairs
     pairs = {(c.owner_id, c.item_id) for c in comments_list}
-    from django.db.models import Q
-
-    q = Q()
-    for owner_id, item_id in pairs:
-        q |= Q(owner_id=owner_id, item_id=item_id)
     shelfmembers: dict[tuple[int, int], ShelfMember] = {}
-    for sm in ShelfMember.objects.filter(q):
-        shelfmembers[(sm.owner_id, sm.item_id)] = sm
-    # Batch-fetch Ratings
     ratings: dict[tuple[int, int], int | None] = {}
-    for r in Rating.objects.filter(q):
-        ratings[(r.owner_id, r.item_id)] = r.grade
+    if pairs:
+        from django.db.models import Q
+
+        q = Q()
+        for owner_id, item_id in pairs:
+            q |= Q(owner_id=owner_id, item_id=item_id)
+        for sm in ShelfMember.objects.filter(q):
+            shelfmembers[(sm.owner_id, sm.item_id)] = sm
+        for r in Rating.objects.filter(q):
+            ratings[(r.owner_id, r.item_id)] = r.grade
     # Pre-set mark and rating_grade on each comment
     for c in comments_list:
         key = (c.owner_id, c.item_id)

--- a/catalog/views/view.py
+++ b/catalog/views/view.py
@@ -192,23 +192,60 @@ def review_list(request, item_path, item_uuid):
     )
 
 
+def _prefetch_comments(comments_list: list["Comment"]):
+    """Batch-fetch marks and ratings for a list of comments to avoid N+1."""
+    if not comments_list:
+        return
+    from journal.models import Rating
+
+    # Batch-fetch ShelfMembers for all (owner, item) pairs
+    pairs = {(c.owner_id, c.item_id) for c in comments_list}
+    from django.db.models import Q
+
+    q = Q()
+    for owner_id, item_id in pairs:
+        q |= Q(owner_id=owner_id, item_id=item_id)
+    shelfmembers: dict[tuple[int, int], ShelfMember] = {}
+    for sm in ShelfMember.objects.filter(q):
+        shelfmembers[(sm.owner_id, sm.item_id)] = sm
+    # Batch-fetch Ratings
+    ratings: dict[tuple[int, int], int | None] = {}
+    for r in Rating.objects.filter(q):
+        ratings[(r.owner_id, r.item_id)] = r.grade
+    # Pre-set mark and rating_grade on each comment
+    for c in comments_list:
+        key = (c.owner_id, c.item_id)
+        m = Mark(c.owner, c.item)
+        m.comment = c
+        m.shelfmember = shelfmembers.get(key)
+        c.__dict__["mark"] = m
+        c.__dict__["rating_grade"] = ratings.get(key)
+
+
 def comments(request, item_path, item_uuid):
     item = get_object_or_404(Item, uid=get_uuid_or_404(item_uuid))
     if item.class_name == "tvseason":
         ids = [item.pk]
     else:
         ids = item.child_item_ids + [item.pk] + item.sibling_item_ids
-    queryset = Comment.objects.filter(item_id__in=ids).order_by("-created_time")
+    queryset = (
+        Comment.objects.filter(item_id__in=ids)
+        .order_by("-created_time")
+        .select_related("owner")
+        .prefetch_related("item")
+    )
     queryset = queryset.filter(q_piece_visible_to_user(request.user))
     before_time = request.GET.get("last")
     if before_time:
         queryset = queryset.filter(created_time__lte=before_time)
+    comments_list = list(queryset[: NUM_COMMENTS_ON_ITEM_PAGE + 1])
+    _prefetch_comments(comments_list)
     return render(
         request,
         "_item_comments.html",
         {
             "item": item,
-            "comments": queryset[: NUM_COMMENTS_ON_ITEM_PAGE + 1],
+            "comments": comments_list,
         },
     )
 

--- a/journal/apis/shelf.py
+++ b/journal/apis/shelf.py
@@ -150,6 +150,7 @@ def list_marks_on_user_shelf(
             type, ItemCategory(category) if category else None
         )
         .filter(qv)
+        .select_related("owner")
         .prefetch_related("item", "item__external_resources")
     )
     return queryset
@@ -170,9 +171,11 @@ def list_marks_on_shelf(
     Shelf's `type` should be one of `wishlist` / `progress` / `complete` / `dropped`;
     `category` is optional, marks for all categories will be returned if not specified.
     """
-    queryset = request.user.shelf_manager.get_latest_members(
-        type, category
-    ).prefetch_related("item", "item__external_resources")
+    queryset = (
+        request.user.shelf_manager.get_latest_members(type, category)
+        .select_related("owner")
+        .prefetch_related("item", "item__external_resources")
+    )
     return queryset
 
 

--- a/journal/apis/shelf.py
+++ b/journal/apis/shelf.py
@@ -1,8 +1,9 @@
 import datetime
-from typing import List
+from typing import Any, List
 
 from django.core.cache import cache
-from django.http import HttpResponse
+from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
 from ninja import Field, Schema
 from ninja.pagination import paginate
@@ -11,7 +12,9 @@ from catalog.models import AvailableItemCategory, Item, ItemCategory, ItemSchema
 from common.api import PageNumberPagination, Result, api
 from common.utils import get_uuid_or_404
 from journal.models.common import max_visiblity_to_user, q_owned_piece_visible_to_user
+from journal.models.rating import Rating
 from journal.models.shelf import ShelfMember
+from journal.models.tag import Tag
 from users.models.apidentity import APIdentity
 
 from ..models import (
@@ -20,6 +23,35 @@ from ..models import (
 )
 
 CALENDAR_CACHE_SECONDS = 6 * 60 * 60
+
+
+def _prefetch_shelf_members(members: list[ShelfMember]):
+    """Batch-fetch related data for shelf members to avoid N+1 queries."""
+    if not members:
+        return
+    items = [m.item for m in members]
+    # Batch-fetch item-level data (public rating/tags for ItemSchema)
+    Rating.attach_to_items(items)
+    Tag.attach_to_items(items)
+    # Batch-fetch user's tags for MarkSchema.tags
+    owner = members[0].owner
+    item_ids = [m.item_id for m in members]
+    tags_by_item = owner.tag_manager.get_items_tags(item_ids)
+    for m in members:
+        m._tags = tags_by_item.get(m.item_id, [])
+
+
+class ShelfPageNumberPagination(PageNumberPagination):
+    def paginate_queryset(
+        self,
+        queryset: QuerySet,
+        pagination: PageNumberPagination.Input,
+        request: HttpRequest,
+        **params: Any,
+    ):
+        val = super().paginate_queryset(queryset, pagination, request, **params)
+        _prefetch_shelf_members(val["data"])
+        return val
 
 
 # Mark
@@ -95,7 +127,7 @@ def get_user_calendar_data(request, handle: str):
     response={200: List[MarkSchema], 401: Result, 403: Result, 404: Result},
     tags=["shelf"],
 )
-@paginate(PageNumberPagination)
+@paginate(ShelfPageNumberPagination)
 def list_marks_on_user_shelf(
     request,
     handle: str,
@@ -118,7 +150,7 @@ def list_marks_on_user_shelf(
             type, ItemCategory(category) if category else None
         )
         .filter(qv)
-        .prefetch_related("item")
+        .prefetch_related("item", "item__external_resources")
     )
     return queryset
 
@@ -128,7 +160,7 @@ def list_marks_on_user_shelf(
     response={200: List[MarkSchema], 401: Result, 403: Result},
     tags=["shelf"],
 )
-@paginate(PageNumberPagination)
+@paginate(ShelfPageNumberPagination)
 def list_marks_on_shelf(
     request, type: ShelfType, category: AvailableItemCategory | None = None
 ):
@@ -140,7 +172,7 @@ def list_marks_on_shelf(
     """
     queryset = request.user.shelf_manager.get_latest_members(
         type, category
-    ).prefetch_related("item")
+    ).prefetch_related("item", "item__external_resources")
     return queryset
 
 

--- a/journal/models/common.py
+++ b/journal/models/common.py
@@ -634,6 +634,10 @@ class PieceInteraction(models.Model):
 
 
 class Content(Piece):
+    if TYPE_CHECKING:
+        owner_id: int
+        item_id: int
+
     owner = models.ForeignKey(APIdentity, on_delete=models.PROTECT)
     visibility = models.PositiveSmallIntegerField(
         choices=VisibilityType.choices, default=0, null=False

--- a/journal/models/shelf.py
+++ b/journal/models/shelf.py
@@ -532,7 +532,10 @@ class ShelfMember(ListMember):
 
     @property
     def tags(self):
-        return self.mark.tags
+        try:
+            return getattr(self, "_tags")
+        except AttributeError:
+            return self.mark.tags
 
     def ensure_log_entry(self):
         log, _ = ShelfLogEntry.objects.get_or_create(

--- a/journal/models/shelf.py
+++ b/journal/models/shelf.py
@@ -337,6 +337,9 @@ class ShelfMemberManager(PolymorphicManager):
 class ShelfMember(ListMember):
     if TYPE_CHECKING:
         parent: models.ForeignKey["ShelfMember", "Shelf"]
+        owner_id: int
+        item_id: int
+        _tags: list[str]
 
     parent = models.ForeignKey(  # type: ignore
         "Shelf", related_name="members", on_delete=models.CASCADE

--- a/journal/models/tag.py
+++ b/journal/models/tag.py
@@ -207,3 +207,15 @@ class TagManager:
                 "parent__title", flat=True
             )
         )
+
+    def get_items_tags(self, item_ids: list[int]) -> dict[int, list[str]]:
+        """Batch-fetch user's tags for multiple items."""
+        tags_by_item: dict[int, list[str]] = {item_id: [] for item_id in item_ids}
+        rows = TagMember.objects.filter(
+            parent__owner=self.owner, item_id__in=item_ids
+        ).values_list("item_id", "parent__title")
+        for item_id, title in rows:
+            tags_by_item[item_id].append(title)
+        for item_id in tags_by_item:
+            tags_by_item[item_id] = sorted(tags_by_item[item_id])
+        return tags_by_item

--- a/journal/views/common.py
+++ b/journal/views/common.py
@@ -18,6 +18,7 @@ from common.utils import (
 )
 
 from ..models import (
+    Mark,
     Piece,
     Rating,
     Review,
@@ -108,10 +109,17 @@ def render_list(
     if year:
         year = int(year)
         queryset = queryset.filter(created_time__year=year)
+    queryset = queryset.prefetch_related("item", "item__external_resources")
     paginator = CustomPaginator(queryset, request)
     page_number = int_(request.GET.get("page", default=1))
     members = paginator.get_page(page_number)
     pagination = PageLinksGenerator(page_number, paginator.num_pages, request.GET)
+    # Batch-fetch marks for all items on this page to avoid N+1 queries
+    items = [m.item for m in members]
+    if items:
+        marks = Mark.get_marks_by_items(target, items, request.user)
+        for m in members:
+            m.__dict__["mark"] = marks.get(m.item_id) or Mark(target, m.item)
     shelf_labels = (
         ShelfManager.get_labels_for_category(item_category) if item_category else []
     )

--- a/tests/journal/test_n_plus_one.py
+++ b/tests/journal/test_n_plus_one.py
@@ -1,0 +1,351 @@
+"""Tests for N+1 query optimizations."""
+
+import pytest
+from django.db import connection
+from django.test import Client
+from django.test.utils import CaptureQueriesContext
+
+from catalog.models import Edition, ExternalResource, IdType, Movie
+from journal.models import Mark, ShelfType, Tag
+from journal.models.shelf import ShelfMember
+from users.models import User
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTagManagerGetItemsTags:
+    """Test the batch tag fetching method."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="tags@example.com", username="taguser")
+        self.book1 = Edition.objects.create(title="Book 1")
+        self.book2 = Edition.objects.create(title="Book 2")
+        self.book3 = Edition.objects.create(title="Book 3")
+
+        tag_a = Tag.objects.create(
+            owner=self.user.identity, title="fiction", visibility=0
+        )
+        tag_b = Tag.objects.create(
+            owner=self.user.identity, title="sci-fi", visibility=0
+        )
+        tag_a.append_item(self.book1)
+        tag_a.append_item(self.book2)
+        tag_b.append_item(self.book1)
+
+    def test_batch_returns_correct_tags(self):
+        tm = self.user.identity.tag_manager
+        result = tm.get_items_tags([self.book1.pk, self.book2.pk, self.book3.pk])
+        assert sorted(result[self.book1.pk]) == ["fiction", "sci-fi"]
+        assert result[self.book2.pk] == ["fiction"]
+        assert result[self.book3.pk] == []
+
+    def test_batch_matches_individual(self):
+        tm = self.user.identity.tag_manager
+        batch = tm.get_items_tags([self.book1.pk, self.book2.pk])
+        individual1 = tm.get_item_tags(self.book1)
+        individual2 = tm.get_item_tags(self.book2)
+        assert sorted(batch[self.book1.pk]) == sorted(individual1)
+        assert sorted(batch[self.book2.pk]) == sorted(individual2)
+
+    def test_empty_list(self):
+        tm = self.user.identity.tag_manager
+        result = tm.get_items_tags([])
+        assert result == {}
+
+    def test_single_query(self):
+        """Batch method should use a single query regardless of item count."""
+        tm = self.user.identity.tag_manager
+        item_ids = [self.book1.pk, self.book2.pk, self.book3.pk]
+        with CaptureQueriesContext(connection) as ctx:
+            tm.get_items_tags(item_ids)
+        tag_queries = [q for q in ctx.captured_queries if "journal_tag" in q["sql"]]
+        assert len(tag_queries) == 1
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestShelfMemberTagsProperty:
+    """Test that ShelfMember.tags uses pre-set _tags when available."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="shelf@example.com", username="shelfuser")
+        self.book = Edition.objects.create(title="Shelf Book")
+        shelf = self.user.identity.shelf_manager.get_shelf(ShelfType.WISHLIST)
+        self.member = ShelfMember.objects.create(
+            owner=self.user.identity,
+            item=self.book,
+            parent=shelf,
+            visibility=0,
+            position=0,
+        )
+
+    def test_preset_tags_used(self):
+        self.member._tags = ["preset-tag-1", "preset-tag-2"]
+        assert self.member.tags == ["preset-tag-1", "preset-tag-2"]
+
+    def test_fallback_to_mark_tags(self):
+        """Without _tags, should fall back to mark.tags."""
+        tag = Tag.objects.create(
+            owner=self.user.identity, title="real-tag", visibility=0
+        )
+        tag.append_item(self.book)
+        member = ShelfMember.objects.get(pk=self.member.pk)
+        assert member.tags == ["real-tag"]
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestMarkBatchFetch:
+    """Test Mark.get_marks_by_items batch fetching."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="mark@example.com", username="markuser")
+        self.books = [Edition.objects.create(title=f"Book {i}") for i in range(5)]
+        # Mark some books
+        Mark(self.user.identity, self.books[0]).update(
+            ShelfType.WISHLIST, "comment0", 7, ["tag0"], 0
+        )
+        Mark(self.user.identity, self.books[1]).update(
+            ShelfType.COMPLETE, "comment1", 8, ["tag1"], 0
+        )
+        Mark(self.user.identity, self.books[2]).update(
+            ShelfType.PROGRESS, None, None, [], 0
+        )
+
+    def test_batch_marks_match_individual(self):
+        marks = Mark.get_marks_by_items(self.user.identity, self.books, self.user)
+        assert len(marks) == 5
+        assert marks[self.books[0].pk].shelf_type == ShelfType.WISHLIST
+        assert marks[self.books[0].pk].comment_text == "comment0"
+        assert marks[self.books[0].pk].rating_grade == 7
+        assert marks[self.books[0].pk].tags == ["tag0"]
+        assert marks[self.books[1].pk].shelf_type == ShelfType.COMPLETE
+        assert marks[self.books[2].pk].shelf_type == ShelfType.PROGRESS
+        assert marks[self.books[3].pk].shelfmember is None
+        assert marks[self.books[4].pk].shelfmember is None
+
+    def test_bounded_queries(self):
+        """Batch fetch should use bounded number of queries."""
+        with CaptureQueriesContext(connection) as ctx:
+            Mark.get_marks_by_items(self.user.identity, self.books, self.user)
+        # Should be bounded: ShelfMember + Comment + Rating + Review + Notes + TagMember
+        # Plus polymorphic model resolution queries (Django polymorphic adds extra queries)
+        # Not proportional to number of items (5 items)
+        assert len(ctx.captured_queries) <= 30
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestRenderListPrefetch:
+    """Test that render_list batch-fetches marks for list members."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="list@example.com", username="listuser")
+        self.books = [Edition.objects.create(title=f"List Book {i}") for i in range(3)]
+        self.tag = Tag.objects.create(
+            owner=self.user.identity, title="test-tag", visibility=0
+        )
+        for book in self.books:
+            Mark(self.user.identity, book).update(
+                ShelfType.WISHLIST, f"comment for {book.title}", 7, ["test-tag"], 0
+            )
+            self.tag.append_item(book)
+
+    def test_tag_list_page_renders(self):
+        client = Client()
+        client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+        response = client.get(
+            f"/users/{self.user.username}/tags/test-tag/",
+        )
+        assert response.status_code == 200
+        for book in self.books:
+            assert book.display_title in response.content.decode()
+
+    def test_tag_list_bounded_queries(self):
+        """Tag list should use bounded queries, not N+1 per item."""
+        client = Client()
+        client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(
+                f"/users/{self.user.username}/tags/test-tag/",
+            )
+        assert response.status_code == 200
+        # Count queries that would be N+1 if not batched:
+        # per-item ShelfMember, Rating, Comment, Review, Tag, ExternalResource
+        shelfmember_queries = [
+            q
+            for q in ctx.captured_queries
+            if "journal_shelfmember" in q["sql"]
+            and "WHERE" in q["sql"]
+            and "item_id" in q["sql"]
+        ]
+        # With batch fetch, shelfmember lookups should be 1 (IN query), not N
+        assert len(shelfmember_queries) <= 2
+
+    def test_shelf_list_page_renders(self):
+        client = Client()
+        client.force_login(self.user, backend="mastodon.auth.OAuth2Backend")
+        response = client.get(
+            f"/users/{self.user.username}/wishlist/book/",
+        )
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestCommentsPrefetch:
+    """Test that comments view prefetches related data."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user1 = User.register(email="c1@example.com", username="commenter1")
+        self.user2 = User.register(email="c2@example.com", username="commenter2")
+        self.book = Edition.objects.create(title="Comment Book")
+
+        # Create marks with comments from two users
+        Mark(self.user1.identity, self.book).update(
+            ShelfType.COMPLETE, "Great book!", 9, [], 0
+        )
+        Mark(self.user2.identity, self.book).update(
+            ShelfType.PROGRESS, "Still reading", None, [], 0
+        )
+
+    def test_comments_page_renders(self):
+        client = Client()
+        response = client.get(
+            f"/book/{self.book.uuid}/comments",
+        )
+        assert response.status_code == 200
+
+    def test_comments_bounded_queries(self):
+        client = Client()
+        client.force_login(self.user1, backend="mastodon.auth.OAuth2Backend")
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(
+                f"/book/{self.book.uuid}/comments",
+            )
+        assert response.status_code == 200
+        # Should NOT have per-comment ShelfMember queries
+        # The batch fetch uses IN queries instead
+        shelfmember_queries = [
+            q
+            for q in ctx.captured_queries
+            if "journal_shelfmember" in q["sql"]
+            and "owner_id" in q["sql"]
+            and "item_id" in q["sql"]
+        ]
+        # With batch fetch: should have at most 1 IN query, not N individual queries
+        assert len(shelfmember_queries) <= 2
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestShelfAPIPrefetch:
+    """Test that shelf API batch-fetches data."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        from takahe.utils import Takahe
+
+        self.user = User.register(email="api@example.com", username="apiuser")
+        self.books = [Edition.objects.create(title=f"API Book {i}") for i in range(3)]
+        for i, book in enumerate(self.books):
+            Mark(self.user.identity, book).update(
+                ShelfType.WISHLIST, f"note {i}", i + 5, [f"tag{i}"], 0
+            )
+            ExternalResource.objects.create(
+                item=book,
+                id_type=IdType.ISBN,
+                id_value=f"978000000000{i}",
+                url=f"https://example.com/book/{i}",
+            )
+        self.app = Takahe.get_or_create_app(
+            "Test",
+            "https://example.org",
+            "https://example.org/cb",
+            owner_pk=self.user.identity.pk,
+        )
+        self.token = Takahe.refresh_token(self.app, self.user.identity.pk, self.user.pk)
+
+    def test_shelf_api_returns_data(self):
+        client = Client()
+        response = client.get(
+            "/api/me/shelf/wishlist",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert len(data) == 3
+        # Verify tags are present
+        all_tags = {tag for item in data for tag in item["tags"]}
+        assert all_tags == {"tag0", "tag1", "tag2"}
+
+    def test_shelf_api_bounded_queries(self):
+        client = Client()
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(
+                "/api/me/shelf/wishlist",
+                HTTP_AUTHORIZATION=f"Bearer {self.token}",
+            )
+        assert response.status_code == 200
+        # With batch: at most 1 IN query for tags, not N individual queries
+        tag_member_individual = [
+            q
+            for q in ctx.captured_queries
+            if "journal_tagmember" in q["sql"]
+            and "item_id" in q["sql"]
+            and "IN" not in q["sql"]
+        ]
+        assert len(tag_member_individual) == 0
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestPrefetchShelfMembers:
+    """Test the _prefetch_shelf_members helper."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="pfx@example.com", username="pfxuser")
+        self.book = Edition.objects.create(title="Prefetch Book")
+        self.movie = Movie.objects.create(title="Prefetch Movie")
+        shelf = self.user.identity.shelf_manager.get_shelf(ShelfType.WISHLIST)
+        self.sm1 = ShelfMember.objects.create(
+            owner=self.user.identity,
+            item=self.book,
+            parent=shelf,
+            visibility=0,
+            position=0,
+        )
+        self.sm2 = ShelfMember.objects.create(
+            owner=self.user.identity,
+            item=self.movie,
+            parent=shelf,
+            visibility=0,
+            position=0,
+        )
+        Tag.objects.create(
+            owner=self.user.identity, title="prefetch-tag", visibility=0
+        ).append_item(self.book)
+
+    def test_prefetch_sets_tags(self):
+        from journal.apis.shelf import _prefetch_shelf_members
+
+        members = list(
+            ShelfMember.objects.filter(owner=self.user.identity).prefetch_related(
+                "item"
+            )
+        )
+        _prefetch_shelf_members(members)
+        tags_map = {m.item_id: m.tags for m in members}
+        assert tags_map[self.book.pk] == ["prefetch-tag"]
+        assert tags_map[self.movie.pk] == []
+
+    def test_prefetch_sets_rating_info(self):
+        from journal.apis.shelf import _prefetch_shelf_members
+
+        members = list(
+            ShelfMember.objects.filter(owner=self.user.identity).prefetch_related(
+                "item"
+            )
+        )
+        _prefetch_shelf_members(members)
+        for m in members:
+            assert hasattr(m.item, "rating_info")


### PR DESCRIPTION
## Summary

- Fix N+1 queries across five high-traffic endpoints identified from Sentry span data over the last 14 days
- Replace per-item database queries with batch operations using `prefetch_related`, `select_related`, and bulk IN queries
- Add `TagManager.get_items_tags()` batch method and `ShelfPageNumberPagination` for post-pagination prefetch

### Endpoints fixed

| Endpoint | Issue | Fix |
|---|---|---|
| `/users/{name}/tags/{title}/` | Per-item Mark queries (~5.25M each) | Batch via `Mark.get_marks_by_items()`, prefetch items/external_resources |
| `/search`, `/api/catalog/search` | Per-item `external_resources` queries (~11M) | `prefetch_related_objects(search_items, "external_resources")` |
| `/{item_path}/{uuid}/comments` | Per-comment owner/mark/rating queries (~2-4.5M) | `select_related("owner")`, batch ShelfMember + Rating fetch |
| `/api/me/shelf/{type}` | Per-item tag/rating/external_resource queries (~2.6M) | Custom paginator with `_prefetch_shelf_members()` |
| `/api/catalog/search` | Missing `Tag.attach_to_items()` | Added batch call |

## Test plan

- [x] 17 new tests in `tests/journal/test_n_plus_one.py` covering all batch methods, prefetch helpers, and bounded query assertions
- [x] All 60 existing journal tests pass
- [x] All 226 existing catalog tests pass
- [x] Lint (`ruff check`) and format (`ruff format`) clean