### PR TITLE
Fix critical bugs, security issues, and logic errors

### DIFF
--- a/catalog/apis.py
+++ b/catalog/apis.py
@@ -150,7 +150,7 @@ def fetch_item(request, url: str, response: HttpResponse):
         response["Location"] = item.api_url
         return 302, {"message": "Item fetched", "url": item.api_url}
     if get_fetch_lock(request.user, url):
-        enqueue_fetch(url, False)
+        enqueue_fetch(url, False, request.user)
     else:
         return 429, {"message": "Try again later"}
     return 202, {"message": "Fetch in progress"}

--- a/catalog/common/downloaders.py
+++ b/catalog/common/downloaders.py
@@ -285,7 +285,7 @@ class BasicDownloader2(BasicDownloader):
             )
 
             return resp, response_type
-        except RequestException as e:
+        except (RequestException, httpx.HTTPError) as e:
             self.logs.append(
                 {"response_type": RESPONSE_NETWORK_ERROR, "url": url, "exception": e}
             )

--- a/catalog/sites/bibliotek_dk.py
+++ b/catalog/sites/bibliotek_dk.py
@@ -159,11 +159,13 @@ class BibliotekDK_Edition(BibliotekDKSite):
             ),
             "cover_image_url": img_url,
             "cover_image_path": img_path,
-            "required_resources": {
-                "model": "Work",
-                "id_type": IdType.BibliotekDK_Work,
-                "id_value": workId,
-            },
+            "required_resources": [
+                {
+                    "model": "Work",
+                    "id_type": IdType.BibliotekDK_Work,
+                    "id_value": workId,
+                },
+            ],
         }
 
         return ResourceContent(

--- a/catalog/sites/douban.py
+++ b/catalog/sites/douban.py
@@ -65,7 +65,6 @@ class DoubanSearcher:
                 item["cover_url"],
             )
             for item in j["items"]
-            for item in j["items"]
             if item.get("tpl_name") == "search_subject"
         ]
         return results

--- a/catalog/sites/douban_book.py
+++ b/catalog/sites/douban_book.py
@@ -89,7 +89,7 @@ class DoubanBook(AbstractSite):
         )
         pub_month = (
             None
-            if pub_month is not None and pub_month not in range(1, 12)
+            if pub_month is not None and pub_month not in range(1, 13)
             else pub_month
         )
 

--- a/catalog/sites/igdb.py
+++ b/catalog/sites/igdb.py
@@ -42,7 +42,10 @@ def _igdb_access_token():
 
 
 def search_igdb_by_3p_url(steam_url):
-    r = IGDB.api_query("websites", f'fields *, game.*; where url = "{steam_url}";')
+    r = IGDB.api_query(
+        "websites",
+        f'fields *, game.*; where url = "{steam_url.replace(chr(34), chr(92) + chr(34))}";',
+    )
     if not r:
         return None
     r = sorted(r, key=lambda w: w["game"]["id"])
@@ -87,7 +90,10 @@ class IGDB(AbstractSite):
 
     def scrape(self):
         fields = "*, cover.url, genres.name, platforms.name, involved_companies.*, involved_companies.company.name"
-        r = self.api_query("games", f'fields {fields}; where url = "{self.url}";')
+        if not self.url:
+            raise ParseError(self, "no url")
+        escaped_url = self.url.replace('"', '\\"')
+        r = self.api_query("games", f'fields {fields}; where url = "{escaped_url}";')
         if not r:
             raise ParseError(self, "no data")
         r = r[0]
@@ -129,7 +135,7 @@ class IGDB(AbstractSite):
         if "genres" in r:
             genre = [g["name"] for g in r["genres"]]
         websites = self.api_query(
-            "websites", f'fields *; where game.url = "{self.url}";'
+            "websites", f'fields *; where game.url = "{escaped_url}";'
         )
         steam_url = None
         official_site = None

--- a/catalog/sites/igdb.py
+++ b/catalog/sites/igdb.py
@@ -44,7 +44,7 @@ def _igdb_access_token():
 def search_igdb_by_3p_url(steam_url):
     r = IGDB.api_query(
         "websites",
-        f'fields *, game.*; where url = "{steam_url.replace(chr(34), chr(92) + chr(34))}";',
+        f'fields *, game.*; where url = "{steam_url.replace('"', '\\"')}";',
     )
     if not r:
         return None

--- a/catalog/sites/rss.py
+++ b/catalog/sites/rss.py
@@ -125,7 +125,7 @@ class RSS(AbstractSite):
                 guid=episode.get("guid"),
                 defaults={
                     "title": episode["title"],
-                    "brief": bleach.clean(episode.get("description"), strip=True),
+                    "brief": bleach.clean(episode.get("description") or "", strip=True),
                     "description_html": episode.get("description_html"),
                     "cover_url": episode.get("episode_art_url"),
                     "media_url": (
@@ -133,8 +133,10 @@ class RSS(AbstractSite):
                         if episode.get("enclosures")
                         else None
                     ),
-                    "pub_date": make_aware(
-                        datetime.fromtimestamp(episode.get("published"))
+                    "pub_date": (
+                        make_aware(datetime.fromtimestamp(episode["published"]))
+                        if episode.get("published") is not None
+                        else None
                     ),
                     "duration": episode.get("duration"),
                     "link": episode.get("link"),

--- a/catalog/views_debug.py
+++ b/catalog/views_debug.py
@@ -23,9 +23,11 @@ from .common import (
 
 def _check_access(request):
     """Check if user has access to debug views."""
+    if not request.user.is_authenticated:
+        return False
     if settings.DEBUG:
         return True
-    return request.user.is_authenticated and request.user.is_superuser
+    return request.user.is_superuser
 
 
 def scraper_debug_page(request):

--- a/common/views.py
+++ b/common/views.py
@@ -32,8 +32,14 @@ def manifest(request):
 
 
 def share(request):
+    from urllib.parse import quote
+
     q = request.GET.get("url") or request.GET.get("text") or request.GET.get("title")
-    return redirect(reverse("common:search") + "?q=" + q) if q else home(request)
+    return (
+        redirect(reverse("common:search") + "?q=" + quote(q, safe=""))
+        if q
+        else home(request)
+    )
 
 
 @login_required

--- a/journal/apis/tag.py
+++ b/journal/apis/tag.py
@@ -104,7 +104,7 @@ def update_tag(request, tag_uuid: str, t_in: TagInSchema):
         return 404, {"message": "Tag not found"}
     if tag.owner != request.user.identity:
         return 403, {"message": "Not owner"}
-    title = Tag.cleanup_title(tag.title)
+    title = Tag.cleanup_title(t_in.title)
     visibility = 2 if t_in.visibility else 0
     if title != tag.title:
         try:

--- a/journal/exporters/ndjson.py
+++ b/journal/exporters/ndjson.py
@@ -34,7 +34,6 @@ class NdjsonExporter(Task):
         "file": None,
         "total": 0,
     }
-    ref_items = []
 
     @property
     def filename(self) -> str:
@@ -57,6 +56,7 @@ class NdjsonExporter(Task):
         }
 
     def run(self):
+        self.ref_items = []
         user = self.user
         temp_dir = tempfile.mkdtemp()
         temp_folder_path = os.path.join(temp_dir, self.filename)

--- a/journal/importers/csv.py
+++ b/journal/importers/csv.py
@@ -224,6 +224,14 @@ class CsvImporter(BaseImporter):
 
         with zipfile.ZipFile(filename, "r") as zipref:
             with tempfile.TemporaryDirectory() as tmpdirname:
+                for member in zipref.namelist():
+                    member_path = os.path.realpath(os.path.join(tmpdirname, member))
+                    if not member_path.startswith(
+                        os.path.realpath(tmpdirname) + os.sep
+                    ) and member_path != os.path.realpath(tmpdirname):
+                        raise ValueError(
+                            f"Zip member {member} would extract outside target directory"
+                        )
                 zipref.extractall(tmpdirname)
 
                 # Count total rows in all CSV files first

--- a/journal/importers/letterboxd.py
+++ b/journal/importers/letterboxd.py
@@ -207,6 +207,14 @@ class LetterboxdImporter(Task):
         with zipfile.ZipFile(filename, "r") as zipref:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 logger.debug(f"Extracting {filename} to {tmpdirname}")
+                for member in zipref.namelist():
+                    member_path = os.path.realpath(os.path.join(tmpdirname, member))
+                    if not member_path.startswith(
+                        os.path.realpath(tmpdirname) + os.sep
+                    ) and member_path != os.path.realpath(tmpdirname):
+                        raise ValueError(
+                            f"Zip member {member} would extract outside target directory"
+                        )
                 zipref.extractall(tmpdirname)
                 if os.path.exists(tmpdirname + "/reviews.csv"):
                     with open(tmpdirname + "/reviews.csv") as f:

--- a/journal/importers/ndjson.py
+++ b/journal/importers/ndjson.py
@@ -237,7 +237,7 @@ class NdjsonImporter(BaseImporter):
             if not item:
                 raise KeyError(f"Could not find item: {data.get('item', '')}")
             rating_grade = int(float(content_data.get("value", 0)))
-            existing_rating = Comment.objects.filter(owner=owner, item=item).first()
+            existing_rating = Rating.objects.filter(owner=owner, item=item).first()
             if (
                 existing_rating
                 and existing_rating.created_time
@@ -452,6 +452,14 @@ class NdjsonImporter(BaseImporter):
 
         with zipfile.ZipFile(filename, "r") as zipref:
             with tempfile.TemporaryDirectory() as tmpdirname:
+                for member in zipref.namelist():
+                    member_path = os.path.realpath(os.path.join(tmpdirname, member))
+                    if not member_path.startswith(
+                        os.path.realpath(tmpdirname) + os.sep
+                    ) and member_path != os.path.realpath(tmpdirname):
+                        raise ValueError(
+                            f"Zip member {member} would extract outside target directory"
+                        )
                 zipref.extractall(tmpdirname)
 
                 # Process actor data first if available

--- a/journal/models/mark.py
+++ b/journal/models/mark.py
@@ -185,7 +185,7 @@ class Mark:
             marks[g.item.pk].rating = g
         for r in Review.objects.filter(item__in=items).filter(q):
             marks[r.item.pk].review = r
-        for n in Review.objects.filter(item__in=items).filter(q):
+        for n in Note.objects.filter(item__in=items).filter(q):
             marks[n.item.pk].notes.append(n)
         for t in (
             TagMember.objects.filter(item__in=items)

--- a/journal/views/collection.py
+++ b/journal/views/collection.py
@@ -242,6 +242,8 @@ def share_collection(
         return False
 
 
+@login_required
+@require_http_methods(["GET"])
 def collection_edit_items(request: AuthedHttpRequest, collection_uuid):
     collection = get_object_or_404(Collection, uid=get_uuid_or_404(collection_uuid))
     if not collection.is_visible_to(request.user):

--- a/journal/views/common.py
+++ b/journal/views/common.py
@@ -16,6 +16,7 @@ from common.utils import (
     get_uuid_or_404,
     target_identity_required,
 )
+from common.validators import get_safe_redirect_url
 
 from ..models import (
     Mark,
@@ -38,7 +39,7 @@ def render_relogin(request):
         request,
         "common/error.html",
         {
-            "url": reverse("mastodon:connect")
+            "url": reverse("mastodon:login")
             + "?domain="
             + request.user.mastodon.domain,
             "msg": _("Data saved but unable to crosspost to Fediverse instance."),
@@ -146,7 +147,7 @@ def render_list(
 @require_http_methods(["GET", "POST"])
 def piece_delete(request, piece_uuid):
     piece = get_object_or_404(Piece, uid=get_uuid_or_404(piece_uuid))
-    return_url = request.GET.get("return_url", None) or "/"
+    return_url = get_safe_redirect_url(request.GET.get("return_url"), "/")
     if not piece.is_editable_by(request.user):
         raise PermissionDenied(_("Insufficient permission"))
     if request.method == "GET":

--- a/journal/views/post.py
+++ b/journal/views/post.py
@@ -123,7 +123,10 @@ def post_delete(request: AuthedHttpRequest, post_id: int):
 @login_required
 def post_reply(request: AuthedHttpRequest, post_id: int):
     content = request.POST.get("content", "").strip()
-    visibility = Takahe.Visibilities(int(request.POST.get("visibility", -1)))
+    try:
+        visibility = Takahe.Visibilities(int(request.POST.get("visibility", "")))
+    except (ValueError, KeyError):
+        raise BadRequest(_("Invalid parameter"))
     if not content:
         raise BadRequest(_("Invalid parameter"))
     post = Takahe.get_post(post_id)

--- a/mastodon/models/mastodon.py
+++ b/mastodon/models/mastodon.py
@@ -42,7 +42,7 @@ class TootVisibilityEnum(StrEnum):
 get = functools.partial(requests.get, timeout=settings.MASTODON_TIMEOUT)
 put = functools.partial(requests.put, timeout=settings.MASTODON_TIMEOUT)
 post = functools.partial(requests.post, timeout=settings.MASTODON_TIMEOUT)
-delete = functools.partial(requests.post, timeout=settings.MASTODON_TIMEOUT)
+delete = functools.partial(requests.delete, timeout=settings.MASTODON_TIMEOUT)
 _sites_cache_key = "login_sites"
 
 # See https://docs.joinmastodon.org/methods/accounts/

--- a/tests/catalog/test_api.py
+++ b/tests/catalog/test_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 import requests
@@ -121,7 +121,7 @@ def test_catalog_fetch_endpoint_returns_accepted_when_queued(live_server):
         )
 
     assert response.status_code == 202
-    enqueue_fetch.assert_called_once_with("http://example.com/queued", False)
+    enqueue_fetch.assert_called_once_with("http://example.com/queued", False, ANY)
 
 
 @pytest.mark.django_db(databases="__all__", transaction=True)

--- a/users/views/data.py
+++ b/users/views/data.py
@@ -43,17 +43,17 @@ def preferences(request):
         tidentity.indexable = bool(request.POST.get("anonymous_viewable"))
         tidentity.save(update_fields=["indexable"])
 
-        preference.default_visibility = int(request.POST.get("default_visibility"))
+        preference.default_visibility = int(request.POST.get("default_visibility", 0))
         preference.mastodon_default_repost = (
             int(request.POST.get("mastodon_default_repost", 0)) == 1
         )
         preference.mastodon_boost_enabled = (
             int(request.POST.get("mastodon_boost_enabled", 0)) == 1
         )
-        preference.classic_homepage = int(request.POST.get("classic_homepage"))
+        preference.classic_homepage = int(request.POST.get("classic_homepage", 0))
         preference.hidden_categories = request.POST.getlist("hidden_categories")
         preference.auto_bookmark_cats = request.POST.getlist("auto_bookmark_cats")
-        preference.post_public_mode = int(request.POST.get("post_public_mode"))
+        preference.post_public_mode = int(request.POST.get("post_public_mode", 0))
         preference.show_last_edit = bool(request.POST.get("show_last_edit"))
         preference.mastodon_repost_mode = int(
             request.POST.get("mastodon_repost_mode", 0)

--- a/users/views/profile.py
+++ b/users/views/profile.py
@@ -70,15 +70,15 @@ def account_profile(request):
 def account_relations(request, typ: str):
     match typ:
         case "follow":
-            ids = request.user.identity.following_identities.all
+            ids = request.user.identity.following_identities.all()
         case "follower":
-            ids = request.user.identity.follower_identities.all
+            ids = request.user.identity.follower_identities.all()
         case "follow_request":
-            ids = request.user.identity.requested_follower_identities.all
+            ids = request.user.identity.requested_follower_identities.all()
         case "mute":
-            ids = request.user.identity.muting_identities.all
+            ids = request.user.identity.muting_identities.all()
         case "block":
-            ids = request.user.identity.blocking_identities.all
+            ids = request.user.identity.blocking_identities.all()
         case _:
             ids = []
     return render(request, "users/relationship_list.html", {"id": typ, "list": ids})


### PR DESCRIPTION
## Summary

- **Security**: Fix open redirect in `piece_delete`, zip slip in all importers, IGDB query injection, unauthenticated SSRF in debug endpoint, URL injection in `share()` view, missing `@login_required` on `collection_edit_items`
- **Critical bugs**: Fix `delete` HTTP helper using POST instead of DELETE, rating import deduplication querying wrong model, doubled list comprehension duplicating Douban search results, `BasicDownloader2` catching wrong exception type, `NoReverseMatch` crash in `render_relogin`, unbound method refs in `account_relations`, notes populated with Review objects instead of Note, `update_tag` API never applying new title, shared mutable `ref_items` in exporter, `range(1,12)` excluding December, `bibliotek_dk` dict instead of list, RSS crashes on missing fields, `post_reply` crash on invalid visibility, `preferences` crash on missing POST fields, missing `request.user` in `enqueue_fetch`

## Test plan
- [ ] Verify toot deletion works (sends DELETE, not POST)
- [ ] Re-import ratings without duplicate IntegrityError
- [ ] Douban search returns correct result count
- [ ] Scraper handles httpx network errors gracefully
- [ ] `piece_delete` rejects external redirect URLs
- [ ] Mastodon crosspost auth failure shows re-login page without crash
- [ ] Follow/follower/mute/block lists render correctly
- [ ] Mark notes display Note objects, not Reviews
- [ ] Zip imports reject path-traversal members
- [ ] IGDB scrape with special chars in URL does not inject queries
- [ ] Debug scraper endpoint requires login
- [ ] `share()` view properly encodes query parameters
- [ ] Tag rename API applies the new title
- [ ] Multiple NDJSON exports produce correct catalog files
- [ ] December publication dates parsed correctly for Douban books
- [ ] BibliotekDK linked resource fetch works
- [ ] RSS feeds with missing episode fields do not crash
- [ ] `post_reply` with invalid visibility returns 400, not 500
- [ ] Preferences save without all fields present
- [ ] Catalog API fetch_item passes user context
- [ ] `collection_edit_items` redirects unauthenticated users to login