### PR TITLE
Include application field in Mastodon Status API responses

### DIFF
--- a/journal/apis/collection.py
+++ b/journal/apis/collection.py
@@ -143,13 +143,15 @@ def create_collection(request, c_in: CollectionInSchema):
     `title`, `brief` (markdown formatted) and `visibility` are required;
     """
     q = (c_in.query or "").strip() or None
-    c = Collection.objects.create(
+    c = Collection(
         owner=request.user.identity,
         title=c_in.title,
         brief=c_in.brief,
         visibility=c_in.visibility,
         query=q,
     )
+    c.application_id_when_save = getattr(request, "application_id", None)
+    c.save()
     return c
 
 
@@ -175,6 +177,7 @@ def update_collection(request, collection_uuid: str, c_in: CollectionInSchema):
     c.brief = c_in.brief
     c.visibility = c_in.visibility
     c.query = q
+    c.application_id_when_save = getattr(request, "application_id", None)
     c.save()
     return c
 

--- a/journal/apis/note.py
+++ b/journal/apis/note.py
@@ -72,6 +72,7 @@ def add_note_for_item(request, item_uuid: str, n_in: NoteInSchema):
     note.progress_value = n_in.progress_value
     note.visibility = n_in.visibility
     note.crosspost_when_save = n_in.post_to_fediverse
+    note.application_id_when_save = getattr(request, "application_id", None)
     note.save()
     return note
 
@@ -95,6 +96,7 @@ def update_note(request, note_uuid: str, n_in: NoteInSchema):
     note.progress_value = n_in.progress_value
     note.visibility = n_in.visibility
     note.crosspost_when_save = n_in.post_to_fediverse
+    note.application_id_when_save = getattr(request, "application_id", None)
     note.save()
     return note
 

--- a/journal/apis/post.py
+++ b/journal/apis/post.py
@@ -73,6 +73,11 @@ class StatusTag(Schema):
     url: str
 
 
+class StatusApplication(Schema):
+    name: str | None = None
+    website: str | None = None
+
+
 class Post(Schema):
     id: str
     uri: str
@@ -103,6 +108,7 @@ class Post(Schema):
     muted: bool = False
     bookmarked: bool = False
     pinned: bool = False
+    application: StatusApplication | None = None
     ext_neodb: dict | None = None
 
 
@@ -143,7 +149,9 @@ def list_posts_for_item(
     result = {
         "data": [
             p.to_mastodon_json()
-            for p in r.posts.prefetch_related("attachments", "author")
+            for p in r.posts.prefetch_related("attachments", "author").select_related(
+                "application"
+            )
         ],
         "pages": r.pages,
         "count": r.total,

--- a/journal/apis/review.py
+++ b/journal/apis/review.py
@@ -96,6 +96,7 @@ def review_item(request, item_uuid: str, review: ReviewInSchema):
         review.visibility,
         created_time=review.created_time,
         share_to_mastodon=review.post_to_fediverse,
+        application_id=getattr(request, "application_id", None),
     )
     return 200, {"message": "OK"}
 

--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -244,7 +244,7 @@ class Collection(List):
             }
         }
 
-    def sync_to_timeline(self, update_mode: int = 0, application_id: int | None = None):
+    def sync_to_timeline(self, update_mode: int = 0):
         existing_post = self.latest_post
         owner: APIdentity = self.owner
         user = owner.user
@@ -273,7 +273,7 @@ class Collection(List):
             existing_post.pk if existing_post else None,
             self.created_time,
             language=owner.user.macrolanguage,
-            application_id=application_id,
+            application_id=self.application_id_when_save,
         )
         if post and post != existing_post:
             self.link_post_id(post.pk)

--- a/journal/models/common.py
+++ b/journal/models/common.py
@@ -144,6 +144,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
     post_when_save: bool = False
     crosspost_when_save: bool = False
     index_when_save: bool = False
+    application_id_when_save: int | None = None
 
     @property
     def classname(self) -> str:
@@ -544,7 +545,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
     def delete_from_timeline(self):
         Takahe.delete_posts(self.all_post_ids)
 
-    def sync_to_timeline(self, update_mode: int = 0, application_id: int | None = None):
+    def sync_to_timeline(self, update_mode: int = 0):
         """update_mode: 0 update if exists otherwise create; 1: delete if exists and create; 2: only create"""
         user = self.owner.user
         v = Takahe.visibility_n2t(self.visibility, user.preference.post_public_mode)
@@ -566,7 +567,7 @@ class Piece(PolymorphicModel, UserOwnedObjectMixin):
             "edit_time": self.edited_time,  # type:ignore subclass must have this
             "data": self.get_ap_data(),
             "language": user.macrolanguage,
-            "application_id": application_id,
+            "application_id": self.application_id_when_save,
         }
         params.update(self.to_post_params())
         post = Takahe.post(**params)  # ty: ignore[invalid-argument-type]

--- a/journal/models/mark.py
+++ b/journal/models/mark.py
@@ -380,7 +380,8 @@ class Mark:
         # publish a new or updated ActivityPub post
         shelfmember = self.shelfmember
         assert shelfmember is not None
-        post = shelfmember.sync_to_timeline(update_mode, application_id=application_id)
+        shelfmember.application_id_when_save = application_id
+        post = shelfmember.sync_to_timeline(update_mode)
         if share_to_mastodon:
             shelfmember.sync_to_social_accounts(update_mode)
         shelfmember.update_index()

--- a/journal/models/review.py
+++ b/journal/models/review.py
@@ -145,6 +145,7 @@ class Review(Content):
         visibility=0,
         created_time=None,
         share_to_mastodon: bool = False,
+        application_id: int | None = None,
     ):
         review = Review.objects.filter(owner=owner, item=item).first()
         if review is not None:
@@ -166,6 +167,7 @@ class Review(Content):
             for name, value in defaults.items():
                 setattr(review, name, value)
         review.crosspost_when_save = share_to_mastodon
+        review.application_id_when_save = application_id
         review.save()
         return review
 

--- a/journal/models/shelf.py
+++ b/journal/models/shelf.py
@@ -446,8 +446,8 @@ class ShelfMember(ListMember):
             data["object"]["relatedWith"].append(self.sibling_rating.ap_object)
         return data
 
-    def sync_to_timeline(self, update_mode: int = 0, application_id: int | None = None):
-        post = super().sync_to_timeline(update_mode, application_id)
+    def sync_to_timeline(self, update_mode: int = 0):
+        post = super().sync_to_timeline(update_mode)
         if post and self.sibling_comment:
             self.sibling_comment.link_post_id(post.id)
         return post

--- a/takahe/models.py
+++ b/takahe/models.py
@@ -1054,6 +1054,7 @@ class Post(models.Model):
 
     if TYPE_CHECKING:
         author_id: int
+        application_id: int | None
         interactions: "models.QuerySet[PostInteraction]"
         attachments: "models.QuerySet[PostAttachment]"
 
@@ -1595,6 +1596,9 @@ class Post(models.Model):
             "card": None,
             "text": self.safe_content_remote(),
             "edited_at": format_ld_date(self.edited) if self.edited else None,
+            "application": self.application.to_mastodon_status_json()
+            if self.application
+            else None,
         }
         if isinstance(self.type_data, dict) and "object" in self.type_data:
             value["ext_neodb"] = self.type_data["object"]
@@ -2521,6 +2525,12 @@ class Application(models.Model):
 
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
+
+    def to_mastodon_status_json(self) -> dict[str, str | None]:
+        return {
+            "name": self.name,
+            "website": self.website,
+        }
 
 
 class Authorization(models.Model):

--- a/takahe/utils.py
+++ b/takahe/utils.py
@@ -507,6 +507,7 @@ class Takahe:
             Post.objects.filter(pk__in=post_pks)
             .exclude(state__in=["deleted", "deleted_fanned_out"])
             .prefetch_related("author", "attachments")
+            .select_related("application")
         )
 
     @staticmethod
@@ -672,6 +673,7 @@ class Takahe:
             .select_related(
                 "author",
                 "author__domain",
+                "application",
             )
             .filter(in_reply_to__in=post_uris)
             .order_by("published")
@@ -803,6 +805,7 @@ class Takahe:
                 "subject_post",
                 "subject_post__author",
                 "subject_post__author__domain",
+                "subject_post__application",
                 "subject_identity",
                 "subject_identity__domain",
                 "subject_post_interaction",
@@ -834,7 +837,9 @@ class Takahe:
         )
         if local_only:
             qs = qs.filter(local=True)
-        return qs.prefetch_related("attachments", "author")
+        return qs.prefetch_related("attachments", "author").select_related(
+            "application"
+        )
 
     @staticmethod
     def get_recent_posts(author_pk: int, viewer_pk: int | None = None):
@@ -849,7 +854,9 @@ class Takahe:
             qs = qs.exclude(visibility=3)
         else:
             qs = qs.filter(visibility__in=[0, 1, 4])
-        return qs.prefetch_related("attachments", "author")
+        return qs.prefetch_related("attachments", "author").select_related(
+            "application"
+        )
 
     @staticmethod
     def pin_hashtag_for_user(identity_pk: int, hashtag: str):

--- a/tests/journal/test_api.py
+++ b/tests/journal/test_api.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from catalog.models import Edition, Game, Movie
 from journal.models import Collection, FeaturedCollection, Mark, Note, Review, Tag
 from journal.models.shelf import ShelfType
+from takahe.models import Post
 from takahe.utils import Takahe
 from users.models import User
 
@@ -720,6 +721,9 @@ def test_post_api_list_for_item():
         def prefetch_related(self, *args, **kwargs):
             return self
 
+        def select_related(self, *args, **kwargs):
+            return self
+
     class StubPost:
         def __init__(self, post_id):
             self.post_id = post_id
@@ -805,3 +809,134 @@ def test_post_api_list_for_item():
     payload = response.json()
     assert payload["count"] == 2
     assert payload["data"][0]["id"] == "1"
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestApplicationOnPosts:
+    """Test that posts created via API have the application field set."""
+
+    @pytest.fixture(autouse=True)
+    def setup_data(self):
+        self.user = User.register(email="apptest@example.com", username="apptestuser")
+        self.item = Edition.objects.create(title="App Test Book")
+        self.app = Takahe.get_or_create_app(
+            "Test App",
+            "https://testapp.example.org",
+            "https://testapp.example.org/callback",
+            owner_pk=self.user.identity.pk,
+        )
+        self.token = Takahe.refresh_token(self.app, self.user.identity.pk, self.user.pk)
+        self.client = Client()
+
+    def _get_post(self, piece) -> Post:
+        post_id = piece.latest_post_id
+        assert post_id is not None
+        post = Takahe.get_post(post_id)
+        assert post is not None
+        return post
+
+    def test_mark_stores_application(self):
+        response = self.client.post(
+            f"/api/me/shelf/item/{self.item.uuid}",
+            data=json.dumps({"shelf_type": "wishlist", "visibility": 0, "tags": []}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        assert response.status_code == 200
+
+        mark = Mark(self.user.identity, self.item)
+        post = self._get_post(mark.shelfmember)
+        assert post.application_id == self.app.pk
+
+        mastodon_json = post.to_mastodon_json()
+        assert mastodon_json["application"] == {
+            "name": "Test App",
+            "website": "https://testapp.example.org",
+        }
+
+    def test_review_stores_application(self):
+        response = self.client.post(
+            f"/api/me/review/item/{self.item.uuid}",
+            data=json.dumps(
+                {
+                    "title": "Review Title",
+                    "body": "Review Body",
+                    "visibility": 0,
+                    "post_to_fediverse": False,
+                }
+            ),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        assert response.status_code == 200
+
+        review = Review.objects.get(owner=self.user.identity, item=self.item)
+        post = self._get_post(review)
+        assert post.application_id == self.app.pk
+
+        mastodon_json = post.to_mastodon_json()
+        assert mastodon_json["application"] == {
+            "name": "Test App",
+            "website": "https://testapp.example.org",
+        }
+
+    def test_note_stores_application(self):
+        response = self.client.post(
+            f"/api/me/note/item/{self.item.uuid}/",
+            data=json.dumps(
+                {
+                    "title": "Note Title",
+                    "content": "Note Content",
+                    "sensitive": False,
+                    "visibility": 0,
+                    "post_to_fediverse": False,
+                }
+            ),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        assert response.status_code == 200
+
+        note = Note.objects.get(owner=self.user.identity, item=self.item)
+        post = self._get_post(note)
+        assert post.application_id == self.app.pk
+
+        mastodon_json = post.to_mastodon_json()
+        assert mastodon_json["application"] == {
+            "name": "Test App",
+            "website": "https://testapp.example.org",
+        }
+
+    def test_collection_stores_application(self):
+        response = self.client.post(
+            "/api/me/collection/",
+            data=json.dumps(
+                {"title": "App Collection", "brief": "desc", "visibility": 0}
+            ),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        assert response.status_code == 200
+        collection_uuid = response.json()["uuid"]
+
+        collection = Collection.get_by_url(collection_uuid)
+        post = self._get_post(collection)
+        assert post.application_id == self.app.pk
+
+        mastodon_json = post.to_mastodon_json()
+        assert mastodon_json["application"] == {
+            "name": "Test App",
+            "website": "https://testapp.example.org",
+        }
+
+    def test_post_without_application(self):
+        """Posts created outside API should have application=None."""
+        mark = Mark(self.user.identity, self.item)
+        mark.update(ShelfType.WISHLIST, visibility=0)
+
+        mark = Mark(self.user.identity, self.item)
+        post = self._get_post(mark.shelfmember)
+        assert post.application_id is None
+
+        mastodon_json = post.to_mastodon_json()
+        assert mastodon_json["application"] is None


### PR DESCRIPTION
## Summary

- Include the `application` field (name + website) in Mastodon-compatible Status JSON output from `Post.to_mastodon_json()`
- Thread `application_id` from OAuth tokens through all API-created content types (marks, reviews, notes, collections) so the originating app is stored on the post
- Unify the pattern using `application_id_when_save` instance attribute on `Piece`, matching the existing `crosspost_when_save` pattern
- Add `select_related("application")` to key query paths to avoid N+1 queries
- Add `StatusApplication` schema to the NeoDB Post API response

Closes #930

## Test plan

- [x] 5 new tests in `TestApplicationOnPosts` covering mark, review, note, collection, and no-application cases
- [x] All 65 journal tests pass
- [x] Pre-commit checks (ruff, ty, djlint) pass