### PR TITLE
Fix gunicorn control socket permission error in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt-run apt-get update \
  && busybox --install \
  && apt-get install -y --no-install-recommends postgresql-client redis-tools gettext \
  && rm -rf /var/lib/apt/lists/* \
- && useradd -U app && mkdir -p /www
+ && useradd -m -U app && mkdir -p /www
 # postgresql and redis cli are not required, but install for development convenience
 
 COPY --from=build /etc/neodb_version /etc/neodb_version


### PR DESCRIPTION
## Summary
- Gunicorn 25.x introduced a control socket feature that defaults to `$HOME/.gunicorn/gunicorn.ctl`
- The `app` user in the Dockerfile was created without `-m`, so `/home/app` does not exist
- This causes `[Errno 13] Permission denied: '/home/app'` on every gunicorn startup (~300 occurrences across both projects)
- Fix: add `-m` flag to `useradd` so the home directory is created

## Sentry issues
- [NEODB-SOCIAL-4EB](https://neodb.sentry.io/issues/NEODB-SOCIAL-4EB) (138 occurrences, escalating)
- [EGGPLANT-18N](https://neodb.sentry.io/issues/EGGPLANT-18N) (153 occurrences)

## Test plan
- [ ] Build Docker image and verify `/home/app` exists
- [ ] Confirm gunicorn starts without "Control server error" in logs