### PR TITLE
Fix IMDB scraping blocked by AWS WAF and add url type hints to downloaders

### DIFF
--- a/catalog/common/downloaders.py
+++ b/catalog/common/downloaders.py
@@ -198,7 +198,9 @@ class BasicDownloader:
 
     timeout = settings.DOWNLOADER_REQUEST_TIMEOUT
 
-    def __init__(self, url, headers: dict | None = None, timeout: float | None = None):
+    def __init__(
+        self, url: str, headers: dict | None = None, timeout: float | None = None
+    ):
         self.url = url
         self.response_type = RESPONSE_OK
         self.logs = []
@@ -370,7 +372,7 @@ class CachedDownloader(BasicDownloader):
 
 
 class ImageDownloaderMixin:
-    def __init__(self, url, referer=None):
+    def __init__(self, url: str, referer=None):
         self.extention = None
         if referer is not None:
             self.headers["Referer"] = referer  # type: ignore
@@ -450,7 +452,7 @@ class ScrapDownloader(BasicDownloader):
 
     def __init__(
         self,
-        url,
+        url: str,
         headers: dict | None = None,
         timeout: float | None = None,
         wait_for_selector: str | None = None,

--- a/catalog/sites/bandcamp.py
+++ b/catalog/sites/bandcamp.py
@@ -58,6 +58,7 @@ class Bandcamp(AbstractSite):
         return False
 
     def scrape(self):
+        assert self.url
         content = BasicDownloader2(self.url).download().html()
         try:
             title = self.query_str(content, "//h2[@class='trackTitle']/text()")

--- a/catalog/sites/bibliotek_dk.py
+++ b/catalog/sites/bibliotek_dk.py
@@ -177,6 +177,7 @@ class BibliotekDK_Edition(BibliotekDKSite):
         )
 
     def scrape(self):
+        assert self.url
         h = BasicDownloader(self.url, {"User-Agent": "curl/8.7.1"}).download().html()
         src = self.query_str(h, '//script[@id="__NEXT_DATA__"]/text()')
         if not src:
@@ -248,6 +249,7 @@ class BibliotekDK_Work(BibliotekDKSite):
         )
 
     def scrape(self):
+        assert self.url
         h = BasicDownloader(self.url, {"User-Agent": "curl/8.7.1"}).download().html()
         src = self.query_str(h, '//script[@id="__NEXT_DATA__"]/text()')
         if not src:

--- a/catalog/sites/bookstw.py
+++ b/catalog/sites/bookstw.py
@@ -18,6 +18,7 @@ class BooksTW(AbstractSite):
         return "https://www.books.com.tw/products/" + id_value
 
     def scrape(self):
+        assert self.url
         content = BasicDownloader(self.url).download().html()
 
         isbn_elem = content.xpath(

--- a/catalog/sites/douban.py
+++ b/catalog/sites/douban.py
@@ -12,7 +12,7 @@ RE_WHITESPACES = re.compile(r"\s+")
 class DoubanDownloader(ScrapDownloader):
     def __init__(
         self,
-        url,
+        url: str,
         headers: dict | None = None,
         timeout: float | None = None,
     ):

--- a/catalog/sites/douban_book.py
+++ b/catalog/sites/douban_book.py
@@ -28,6 +28,7 @@ class DoubanBook(AbstractSite):
         return DoubanSearcher.search(ItemCategory.Book, "book", q, p)
 
     def scrape(self):
+        assert self.url
         content = DoubanDownloader(self.url).download().html()
 
         isbn_elem = self.query_list(
@@ -269,6 +270,7 @@ class DoubanBook_Work(AbstractSite):
         return "https://book.douban.com/works/" + id_value + "/"
 
     def scrape(self):
+        assert self.url
         content = DoubanDownloader(self.url).download().html()
         title_elem = self.query_list(content, "//h1/text()")
         title = title_elem[0].split("全部版本(")[0].strip() if title_elem else None

--- a/catalog/sites/douban_drama.py
+++ b/catalog/sites/douban_drama.py
@@ -125,6 +125,7 @@ class DoubanDrama(AbstractSite):
         return "https://www.douban.com/location/drama/" + id_value + "/"
 
     def scrape(self):
+        assert self.url
         key = _cache_key(self.url)
         r = cache.get(key, None)
         if r is None:

--- a/catalog/sites/douban_game.py
+++ b/catalog/sites/douban_game.py
@@ -26,6 +26,7 @@ class DoubanGame(AbstractSite):
         return "https://www.douban.com/game/" + id_value + "/"
 
     def scrape(self):
+        assert self.url
         content = DoubanDownloader(self.url).download().html()
 
         elem = self.query_list(content, "//div[@id='content']/h1/text()")

--- a/catalog/sites/douban_movie.py
+++ b/catalog/sites/douban_movie.py
@@ -34,6 +34,7 @@ class DoubanMovie(AbstractSite):
         return DoubanSearcher.search(ItemCategory.Movie, "movie", q, p)
 
     def scrape(self):
+        assert self.url
         content = DoubanDownloader(self.url).download().html()
         try:
             schema_data = "".join(

--- a/catalog/sites/douban_music.py
+++ b/catalog/sites/douban_music.py
@@ -30,6 +30,7 @@ class DoubanMusic(AbstractSite):
         return DoubanSearcher.search(ItemCategory.Music, "music", q, p)
 
     def scrape(self):
+        assert self.url
         content = DoubanDownloader(self.url).download().html()
 
         elem = self.query_list(content, "//h1/span/text()")

--- a/catalog/sites/goodreads.py
+++ b/catalog/sites/goodreads.py
@@ -60,6 +60,7 @@ class Goodreads(AbstractSite):
         if response is not None:
             h = html.fromstring(response.text.strip())
         else:
+            assert self.url
             dl = GoodreadsDownloader(self.url)
             h = dl.download().html()
         # Next.JS version of GoodReads
@@ -232,6 +233,7 @@ class Goodreads_Work(AbstractSite):
         return "https://www.goodreads.com/work/editions/" + id_value
 
     def scrape(self, response=None):
+        assert self.url
         content = BasicDownloader(self.url).download().html()
         title = self.query_str(content, "//h1/a/text()")
         if not title:

--- a/catalog/sites/imdb.py
+++ b/catalog/sites/imdb.py
@@ -10,6 +10,27 @@ from .tmdb import search_tmdb_by_imdb_id
 _logger = logging.getLogger(__name__)
 
 
+class IMDBDownloader(ScrapDownloader):
+    def __init__(
+        self,
+        url: str,
+        headers: dict | None = None,
+        timeout: float | None = None,
+    ):
+        super().__init__(url, headers, timeout, 'script[id="__NEXT_DATA__"]')
+
+    def validate_response(self, response) -> int:
+        if response is None:
+            return RESPONSE_NETWORK_ERROR
+        elif response.status_code == 200:
+            content = response.content.decode("utf-8")
+            if "__NEXT_DATA__" not in content:
+                return RESPONSE_NETWORK_ERROR
+            return RESPONSE_OK
+        else:
+            return RESPONSE_INVALID_CONTENT
+
+
 @SiteManager.register
 class IMDB(AbstractSite):
     """
@@ -71,7 +92,8 @@ class IMDB(AbstractSite):
         return pd
 
     def scrape_imdb(self):
-        h = BasicDownloader(self.url).download().html()
+        assert self.url
+        h = IMDBDownloader(self.url).download().html()
         src = self.query_str(h, '//script[@id="__NEXT_DATA__"]/text()')
         if not src:
             raise ParseError(self, "__NEXT_DATA__ element")
@@ -117,13 +139,13 @@ class IMDB(AbstractSite):
     @staticmethod
     def get_episode_list(show_id, season_id):
         url = f"https://m.imdb.com/title/{show_id}/"
-        h = BasicDownloader(url).download().html()
+        h = IMDBDownloader(url).download().html()
         u: str = h.xpath('//a[@data-testid="hero-title-block__series-link"]/@href')
         show_url = "".join(u).split("?")[0]
         if not show_url:
             show_url = f"/title/{show_id}/"
         url = f"https://m.imdb.com{show_url}episodes/?season={season_id}"
-        h = BasicDownloader(url).download().html()
+        h = IMDBDownloader(url).download().html()
         episodes = []
         for e in h.xpath("//article//a[contains(@class,'ipc-title-link-wrapper')]"):
             title = e.xpath("div[contains(@class,'ipc-title__text')]/text()")[0].split(

--- a/catalog/sites/qidian.py
+++ b/catalog/sites/qidian.py
@@ -18,6 +18,7 @@ class Qidian(AbstractSite):
         return f"https://book.qidian.com/info/{id_value}/"
 
     def scrape(self):
+        assert self.url
         content = ProxiedDownloader(self.url).download().html()
         title_elem = content.xpath('//*[@id="bookName"]/text()')
         title = (

--- a/catalog/sites/spotify.py
+++ b/catalog/sites/spotify.py
@@ -41,6 +41,7 @@ class Spotify(AbstractSite):
         return f"https://open.spotify.com/album/{id_value}"
 
     def scrape_web(self):
+        assert self.url
         content = BasicDownloader(self.url).download().html()
         txt: str = content.xpath("//script[@type='application/ld+json']/text()")[0]
         schema_data = json.loads(txt)

--- a/catalog/sites/worldcat.py
+++ b/catalog/sites/worldcat.py
@@ -30,6 +30,7 @@ class WorldCat(AbstractSite):
         return f"https://search.worldcat.org/title/{id_value}"
 
     def scrape(self):
+        assert self.url
         response = BasicDownloader(self.url).download()
         content = response.html()
 


### PR DESCRIPTION
## Summary
- Use `ScrapDownloader` (with JS rendering support via configured scraping providers) for IMDB pages instead of `BasicDownloader`, which fails with HTTP 202 when IMDB returns an AWS WAF JavaScript challenge page
- Add `IMDBDownloader` class (following the `DoubanDownloader` pattern) that waits for `__NEXT_DATA__` selector and validates the response contains the expected data
- Add `url: str` type hint to `BasicDownloader.__init__`, `ScrapDownloader.__init__`, `ImageDownloaderMixin.__init__`, `DoubanDownloader.__init__`, and `IMDBDownloader.__init__`
- Add `assert self.url` type narrowing in all site scrape methods that pass `AbstractSite.url` to a downloader

## Test plan
- [x] All existing IMDB tests pass (10 tests)
- [x] All affected site tests pass (42 tests covering imdb, douban, goodreads, bandcamp, spotify, bibliotek, bookstw, worldcat, qidian)
- [x] Pre-commit checks pass (ruff, ruff format, ty type checker, djlint)
- [ ] Verify IMDB scraping works in production with a configured scraping provider (e.g. scrapfly, scraperapi)