### PR TITLE
Linkify URLs in comments and collection notes

### DIFF
--- a/journal/models/collection.py
+++ b/journal/models/collection.py
@@ -17,7 +17,7 @@ from users.models import APIdentity
 
 from .common import Piece
 from .itemlist import List, ListMember
-from .renderers import render_md
+from .renderers import render_md, render_text
 
 _RE_HTML_TAG = re.compile(r"<[^>]*>")
 
@@ -28,6 +28,10 @@ class CollectionMember(ListMember):
     )
 
     note = jsondata.CharField(_("note"), null=True, blank=True)
+
+    @property
+    def note_html(self) -> str:
+        return render_text(self.note) if self.note else ""
 
     @property
     def ap_object(self):

--- a/journal/models/renderers.py
+++ b/journal/models/renderers.py
@@ -43,8 +43,7 @@ def render_md(s: str) -> str:
 _RE_HTML_TAG = re.compile(r"<[^>]*>")
 
 _URL_REGEX = re.compile(
-    r"""(\(*  # Match any opening parentheses.
-    \b(?<![@.])(?:https?://(?:(?:\w+:)?\w+@)?)  # http://
+    r"""(\b(?<![@.])(?:https?://(?:(?:\w+:)?\w+@)?)  # http://
     (?:[\w-]+\.)+(?:[\w-]+)(?:\:[0-9]+)?(?!\.\w)\b   # xx.yy.tld(:##)?
     (?:[/?][^\s\{{\}}\|\\\^\[\]`<>"]*)?)
     # /path/zz (excluding "unsafe" chars from RFC 1738,

--- a/journal/models/renderers.py
+++ b/journal/models/renderers.py
@@ -80,7 +80,7 @@ def has_spoiler(s: str) -> bool:
     return ">!" in s
 
 
-def _spolier(s: str) -> str:
+def _spoiler(s: str) -> str:
     sl = s.split(">!", 1)
     if len(sl) == 1:
         return _linkify(s)
@@ -90,12 +90,12 @@ def _spolier(s: str) -> str:
         + '<span class="spoiler" _="on click toggle .revealed on me">'
         + _linkify(r[0])
         + "</span>"
-        + (_spolier(r[1]) if len(r) == 2 else "")
+        + (_spoiler(r[1]) if len(r) == 2 else "")
     )
 
 
 def render_text(s: str) -> str:
-    return _spolier(s).strip().replace("\n", "<br>")
+    return _spoiler(s).strip().replace("\n", "<br>")
 
 
 def render_title_as_hashtag(t: str) -> str:

--- a/journal/models/renderers.py
+++ b/journal/models/renderers.py
@@ -42,6 +42,17 @@ def render_md(s: str) -> str:
 
 _RE_HTML_TAG = re.compile(r"<[^>]*>")
 
+_URL_REGEX = re.compile(
+    r"""(\(*  # Match any opening parentheses.
+    \b(?<![@.])(?:https?://(?:(?:\w+:)?\w+@)?)  # http://
+    (?:[\w-]+\.)+(?:[\w-]+)(?:\:[0-9]+)?(?!\.\w)\b   # xx.yy.tld(:##)?
+    (?:[/?][^\s\{{\}}\|\\\^\[\]`<>"]*)?)
+    # /path/zz (excluding "unsafe" chars from RFC 1738,
+    # except for # and ~, which happen in practice)
+    """,
+    re.IGNORECASE | re.VERBOSE | re.UNICODE,
+)
+
 
 def html_to_text(h: str) -> str:
     return unescape(
@@ -51,6 +62,21 @@ def html_to_text(h: str) -> str:
     )
 
 
+def _linkify(s: str) -> str:
+    """Escape text and convert URLs to hyperlinks."""
+    bits = _URL_REGEX.split(s)
+    parts: list[str] = []
+    for i, bit in enumerate(bits):
+        if i % 2 == 1:
+            escaped = escape(bit)
+            parts.append(
+                f'<a href="{escaped}" rel="nofollow" target="_blank">{escaped}</a>'
+            )
+        else:
+            parts.append(escape(bit))
+    return "".join(parts)
+
+
 def has_spoiler(s: str) -> bool:
     return ">!" in s
 
@@ -58,12 +84,12 @@ def has_spoiler(s: str) -> bool:
 def _spolier(s: str) -> str:
     sl = s.split(">!", 1)
     if len(sl) == 1:
-        return escape(s)
+        return _linkify(s)
     r = sl[1].split("!<", 1)
     return (
-        escape(sl[0])
+        _linkify(sl[0])
         + '<span class="spoiler" _="on click toggle .revealed on me">'
-        + escape(r[0])
+        + _linkify(r[0])
         + "</span>"
         + (_spolier(r[1]) if len(r) == 2 else "")
     )

--- a/journal/templates/_list_item.html
+++ b/journal/templates/_list_item.html
@@ -72,7 +72,11 @@
                 </span>
               {% endif %}
             {% endif %}
-            {{ collection_member.note|default:'&nbsp;'|linebreaksbr }}
+            {% if collection_member.note %}
+              {{ collection_member.note_html|safe }}
+            {% else %}
+              &nbsp;
+            {% endif %}
           </div>
         </section>
       {% endif %}

--- a/tests/journal/test_renderers.py
+++ b/tests/journal/test_renderers.py
@@ -1,0 +1,95 @@
+import pytest
+
+from journal.models.renderers import _linkify, render_text
+
+
+def _link(url: str) -> str:
+    """Helper to build expected anchor tag for a URL."""
+    return f'<a href="{url}" rel="nofollow" target="_blank">{url}</a>'
+
+
+class TestLinkify:
+    def test_plain_text_no_urls(self):
+        assert _linkify("just some text") == "just some text"
+
+    def test_single_url(self):
+        assert _linkify("visit https://example.com today") == (
+            f"visit {_link('https://example.com')} today"
+        )
+
+    def test_url_with_path(self):
+        url = "https://eggplant.place/movie/7DWrhJ7Mz"
+        assert _linkify(f"see {url}") == f"see {_link(url)}"
+
+    def test_multiple_urls(self):
+        result = _linkify("see https://a.com and https://b.com/path")
+        assert _link("https://a.com") in result
+        assert _link("https://b.com/path") in result
+
+    def test_url_with_query_params(self):
+        result = _linkify("visit https://example.com/path?q=1&x=2")
+        assert 'href="https://example.com/path?q=1&amp;x=2"' in result
+
+    def test_escapes_html_in_text(self):
+        result = _linkify("a < b > c")
+        assert "&lt;" in result
+        assert "&gt;" in result
+
+    def test_escapes_script_tags(self):
+        result = _linkify("<script>alert(1)</script>")
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
+    def test_http_url(self):
+        assert _link("http://example.com") in _linkify("visit http://example.com")
+
+    def test_url_with_port(self):
+        url = "https://example.com:8080/path"
+        assert _link(url) in _linkify(f"at {url}")
+
+    def test_empty_string(self):
+        assert _linkify("") == ""
+
+
+class TestRenderText:
+    def test_plain_text(self):
+        assert render_text("hello world") == "hello world"
+
+    def test_url_linkified(self):
+        result = render_text("visit https://example.com for info")
+        assert _link("https://example.com") in result
+
+    def test_newlines_to_br(self):
+        result = render_text("line 1\nline 2")
+        assert "<br>" in result
+
+    def test_url_across_newlines(self):
+        result = render_text("before\nhttps://example.com\nafter")
+        assert _link("https://example.com") in result
+        assert "<br>" in result
+
+    def test_spoiler_without_url(self):
+        result = render_text("check >!secret!< here")
+        assert '<span class="spoiler"' in result
+        assert "secret" in result
+
+    def test_url_inside_spoiler(self):
+        result = render_text("check >!https://secret.com!< here")
+        assert '<span class="spoiler"' in result
+        assert _link("https://secret.com") in result
+
+    def test_url_outside_spoiler(self):
+        result = render_text("see https://public.com and >!hidden!<")
+        assert _link("https://public.com") in result
+        assert '<span class="spoiler"' in result
+
+    def test_html_escaped(self):
+        result = render_text("<b>bold</b>")
+        assert "<b>" not in result
+        assert "&lt;b&gt;" in result
+
+    def test_strips_whitespace(self):
+        assert render_text("  hello  ") == "hello"
+
+    def test_empty_string(self):
+        assert render_text("") == ""

--- a/tests/journal/test_renderers.py
+++ b/tests/journal/test_renderers.py
@@ -45,6 +45,9 @@ class TestLinkify:
         url = "https://example.com:8080/path"
         assert _link(url) in _linkify(f"at {url}")
 
+    def test_url_in_parentheses(self):
+        assert _linkify("(https://example.com)") == f"({_link('https://example.com')})"
+
     def test_empty_string(self):
         assert _linkify("") == ""
 

--- a/tests/journal/test_renderers.py
+++ b/tests/journal/test_renderers.py
@@ -1,5 +1,3 @@
-import pytest
-
 from journal.models.renderers import _linkify, render_text
 
 


### PR DESCRIPTION
## Summary
- Add URL linkification to `render_text()` so URLs in comments are hyperlinked on item pages and in collections (matching the existing feed behavior)
- Use the same URL regex pattern already used by the Fediverse feed renderer
- Add `note_html` property to `CollectionMember` for linkified collection notes
- Add 20 tests for `_linkify` and `render_text`

Fixes #1350

## Test plan
- [x] 20 unit tests for `_linkify` and `render_text` covering URLs, spoilers, HTML escaping, edge cases
- [ ] Verify URLs in comments are clickable on item detail pages
- [ ] Verify URLs in collection notes are clickable
- [ ] Verify spoiler text with URLs still works correctly
- [ ] Verify no XSS via malicious input in comments