### PR TITLE
Show post feed for non-neodb remote user profiles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,13 @@
 * **Please check if the PR fulfills these requirements**
-- [ ] Changes were fully written by a human or have been fully reviewed (every single line) by a human
-- [ ] Tests for the changes have been added (for bug fixes / features)
-- [ ] Docs have been added / updated (for features)
-- [ ] Migration has been added, or considered but not needed.
+- [ ] You, as a human, have fully reviewed every single line of this PR
+- [ ] You, as a human, have fully tested this PR
 
-* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 
+* **What kind of change does this PR introduce?**
+- [ ] bug fix, including security or performance improvements
+- [ ] feature
+- [ ] docs
+- [ ] other
 
 
 * **What is the current behavior?** (Link to an open issue if applicable)

--- a/journal/apis/collection.py
+++ b/journal/apis/collection.py
@@ -3,11 +3,12 @@ from typing import List
 
 from django.core.cache import cache
 from django.db.models import Count
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from django.utils import timezone
 from django.views.decorators.cache import cache_page
 from ninja import Field, Schema
 from ninja.decorators import decorate_view
+from ninja.errors import HttpError
 from ninja.pagination import paginate
 
 from catalog.models import Item, ItemSchema
@@ -126,9 +127,9 @@ def collection_list_items(request, collection_uuid: str):
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        raise Http404("Collection not found")
     if not c.is_visible_to(request.user):
-        return 403, {"message": "Permission denied"}
+        raise HttpError(403, "Permission denied")
     if c.is_dynamic:
         items = c.query_result.items if c.query_result else []
         members = [{"item": i, "note": ""} for i in items]
@@ -218,9 +219,9 @@ def user_collection_list_items(request, collection_uuid: str):
     """
     c = Collection.get_by_url(collection_uuid)
     if not c:
-        return 404, {"message": "Collection not found"}
+        raise Http404("Collection not found")
     if c.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        raise HttpError(403, "Not owner")
     if c.is_dynamic:
         items = c.query_result.items if c.query_result else []
         members = [{"item": i, "note": ""} for i in items]
@@ -292,7 +293,7 @@ def list_item_collections(request, item_uuid: str):
     """
     item = Item.get_by_url(item_uuid, resolve_merge=True)
     if not item or item.is_deleted:
-        return 404, {"message": "Item not found"}
+        raise Http404("Item not found")
     qv = q_piece_visible_to_user(request.user)
     return Collection.objects.filter(items=item).filter(qv).order_by("-created_time")
 

--- a/journal/apis/note.py
+++ b/journal/apis/note.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import List
 
+from django.http import Http404
 from ninja import Field, Schema
 from ninja.pagination import paginate
 
@@ -45,7 +46,7 @@ def list_notes_for_item(request, item_uuid):
     """
     item = Item.get_by_url(item_uuid)
     if not item:
-        return 404, {"message": "Item not found"}
+        raise Http404("Item not found")
     queryset = Note.objects.filter(owner=request.user.identity, item=item)
     return queryset.prefetch_related("item")
 

--- a/journal/apis/shelf.py
+++ b/journal/apis/shelf.py
@@ -3,7 +3,7 @@ from typing import Any, List
 
 from django.core.cache import cache
 from django.db.models import QuerySet
-from django.http import HttpRequest, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.utils import timezone
 from ninja import Field, Schema
 from ninja.pagination import paginate
@@ -295,7 +295,7 @@ def get_mark_logs_by_item(request, item_uuid: str, response: HttpResponse):
     """
     item = Item.get_by_url(item_uuid)
     if not item or item.is_deleted:
-        return 404, {"message": "Item not found"}
+        raise Http404("Item not found")
     if item.merged_to_item:
         response["Location"] = f"/api/me/shelf/item/{item.merged_to_item.uuid}/logs"
         return 302, {"message": "Item merged", "url": item.merged_to_item.api_url}

--- a/journal/apis/tag.py
+++ b/journal/apis/tag.py
@@ -1,7 +1,9 @@
 from typing import List
 
 from django.core.cache import cache
+from django.http import Http404
 from ninja import Field, Schema
+from ninja.errors import HttpError
 from ninja.pagination import paginate
 
 from catalog.models import Item, ItemSchema
@@ -146,9 +148,9 @@ def tag_list_items(request, tag_uuid: str):
     """
     tag = Tag.get_by_url(tag_uuid)
     if not tag:
-        return 404, {"message": "Tag not found"}
+        raise Http404("Tag not found")
     if tag.owner != request.user.identity:
-        return 403, {"message": "Not owner"}
+        raise HttpError(403, "Not owner")
     return tag.members.all()
 
 

--- a/journal/templates/profile.html
+++ b/journal/templates/profile.html
@@ -29,63 +29,54 @@
     {% include "_header.html" %}
     <main>
       <div class="grid__main">
-        <div class="sortable"></div>
-        <div class="unsorted" style="display:none;">
-          {% if request.user.is_authenticated %}
-            <section class="entity-sort shelf" id="calendar_grid">
-              <span class="action">
-                <span>
-                  <a _="on click set el to the next <ul/> then call el.scrollBy({left:-el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-left"></i></a>
-                </span>
-                <span>
-                  <a _="on click set el to the next <ul/> then call el.scrollBy({left:el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-right"></i></a>
-                </span>
-              </span>
-              <h5>
-                {% trans "calendar" %}
-                {% if year %}
-                  <small>
-                    <a href="{% url 'journal:wrapped' year %}">{{ year }} {% trans "annual summary" %}</a>
-                  </small>
-                {% endif %}
-              </h5>
-              <ul class="calendar_view cards">
-                <p style="text-align: center;">
-                  <i class="fa-solid fa-compact-disc fa-spin loading"></i>
-                </p>
-              </ul>
-              <span class="calendar_data"
-                    hx-get="{% url 'journal:user_calendar_data' identity.handle %}"
-                    hx-trigger="intersect once queue:last"
-                    hx-swap="innerHTML"></span>
-            </section>
-          {% endif %}
-          {% for collection in pinned_collections %}
-            <section class="entity-sort shelf" id="collection_{{ collection.uuid }}">
-              <div hx-swap="outerHTML"
-                   hx-get="{% url 'journal:profile_collection_items' collection.uuid %}"
-                   hx-trigger="intersect once queue:last">
-                <h5>{{ collection.title }}</h5>
-                <ul class="cards">
-                  <li class="card">
-                    <a>
-                      <img src="{{ default_cover_url }}" alt="" loading="lazy">
-                      <div>
-                        <i class="fa-solid fa-compact-disc fa-spin loading"></i>
-                      </div>
-                    </a>
-                  </li>
-                </ul>
+        {% if feed_view %}
+          <section>
+            <article>
+              <div hx-get="{% url 'journal:profile_posts_data' identity.handle %}"
+                   hx-trigger="intersect once delay:0.1s"
+                   hx-swap="outerHTML">
+                <i class="fa-solid fa-compact-disc fa-spin loading"></i>
               </div>
-            </section>
-          {% endfor %}
-          {% for category, category_shelves in shelf_list.items %}
-            {% for shelf_type, shelf in category_shelves.items %}
-              <section class="entity-sort shelf" id="{{ category }}_{{ shelf_type }}">
+            </article>
+          </section>
+        {% else %}
+          <div class="sortable"></div>
+          <div class="unsorted" style="display:none;">
+            {% if request.user.is_authenticated %}
+              <section class="entity-sort shelf" id="calendar_grid">
+                <span class="action">
+                  <span>
+                    <a _="on click set el to the next <ul/> then call el.scrollBy({left:-el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-left"></i></a>
+                  </span>
+                  <span>
+                    <a _="on click set el to the next <ul/> then call el.scrollBy({left:el.offsetWidth, behavior:'smooth'})"><i class="fa-solid fa-circle-right"></i></a>
+                  </span>
+                </span>
+                <h5>
+                  {% trans "calendar" %}
+                  {% if year %}
+                    <small>
+                      <a href="{% url 'journal:wrapped' year %}">{{ year }} {% trans "annual summary" %}</a>
+                    </small>
+                  {% endif %}
+                </h5>
+                <ul class="calendar_view cards">
+                  <p style="text-align: center;">
+                    <i class="fa-solid fa-compact-disc fa-spin loading"></i>
+                  </p>
+                </ul>
+                <span class="calendar_data"
+                      hx-get="{% url 'journal:user_calendar_data' identity.handle %}"
+                      hx-trigger="intersect once queue:last"
+                      hx-swap="innerHTML"></span>
+              </section>
+            {% endif %}
+            {% for collection in pinned_collections %}
+              <section class="entity-sort shelf" id="collection_{{ collection.uuid }}">
                 <div hx-swap="outerHTML"
-                     hx-get="{% url 'journal:profile_shelf_items' identity.handle category shelf_type %}"
+                     hx-get="{% url 'journal:profile_collection_items' collection.uuid %}"
                      hx-trigger="intersect once queue:last">
-                  <h5>{{ shelf.title }}</h5>
+                  <h5>{{ collection.title }}</h5>
                   <ul class="cards">
                     <li class="card">
                       <a>
@@ -99,44 +90,64 @@
                 </div>
               </section>
             {% endfor %}
-          {% endfor %}
-          <section class="entity-sort shelf" id="collection_created">
-            <div hx-swap="outerHTML"
-                 hx-get="{% url 'journal:profile_created_collections' identity.handle %}"
-                 hx-trigger="intersect once queue:last">
-              <h5>{% trans 'collection' %}</h5>
-              <ul class="cards">
-                <li class="card">
-                  <a>
-                    <img src="{{ default_cover_url }}" alt="" loading="lazy">
-                    <div>
-                      <i class="fa-solid fa-compact-disc fa-spin loading"></i>
-                    </div>
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </section>
-          <section class="entity-sort shelf" id="collection_marked">
-            <div hx-swap="outerHTML"
-                 hx-get="{% url 'journal:profile_liked_collections' identity.handle %}"
-                 hx-trigger="intersect once queue:last">
-              <h5>{% trans 'liked collection' %}</h5>
-              <ul class="cards">
-                <li class="card">
-                  <a>
-                    <img src="{{ default_cover_url }}" alt="" loading="lazy">
-                    <div>
-                      <i class="fa-solid fa-compact-disc fa-spin loading"></i>
-                    </div>
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </section>
-        </div>
-        {{ layout|json_script:"layout-data" }}
-        <script>
+            {% for category, category_shelves in shelf_list.items %}
+              {% for shelf_type, shelf in category_shelves.items %}
+                <section class="entity-sort shelf" id="{{ category }}_{{ shelf_type }}">
+                  <div hx-swap="outerHTML"
+                       hx-get="{% url 'journal:profile_shelf_items' identity.handle category shelf_type %}"
+                       hx-trigger="intersect once queue:last">
+                    <h5>{{ shelf.title }}</h5>
+                    <ul class="cards">
+                      <li class="card">
+                        <a>
+                          <img src="{{ default_cover_url }}" alt="" loading="lazy">
+                          <div>
+                            <i class="fa-solid fa-compact-disc fa-spin loading"></i>
+                          </div>
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </section>
+              {% endfor %}
+            {% endfor %}
+            <section class="entity-sort shelf" id="collection_created">
+              <div hx-swap="outerHTML"
+                   hx-get="{% url 'journal:profile_created_collections' identity.handle %}"
+                   hx-trigger="intersect once queue:last">
+                <h5>{% trans 'collection' %}</h5>
+                <ul class="cards">
+                  <li class="card">
+                    <a>
+                      <img src="{{ default_cover_url }}" alt="" loading="lazy">
+                      <div>
+                        <i class="fa-solid fa-compact-disc fa-spin loading"></i>
+                      </div>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </section>
+            <section class="entity-sort shelf" id="collection_marked">
+              <div hx-swap="outerHTML"
+                   hx-get="{% url 'journal:profile_liked_collections' identity.handle %}"
+                   hx-trigger="intersect once queue:last">
+                <h5>{% trans 'liked collection' %}</h5>
+                <ul class="cards">
+                  <li class="card">
+                    <a>
+                      <img src="{{ default_cover_url }}" alt="" loading="lazy">
+                      <div>
+                        <i class="fa-solid fa-compact-disc fa-spin loading"></i>
+                      </div>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </section>
+          </div>
+          {{ layout|json_script:"layout-data" }}
+          <script>
           const initialLayoutData = JSON.parse(document.getElementById('layout-data').textContent);
           initialLayoutData.forEach(elem => {
             $('#' + elem.id).data('visibility', elem.visibility);
@@ -148,43 +159,49 @@
           $('.unsorted .entity-sort').each((i, elem) => {
               $('.sortable').append(elem);
           });
-        </script>
-        {% if identity.user == request.user %}
-          <div class="entity-sort-control">
-            <div class="entity-sort-control__button" id="sortEditButton">
-              <span class="entity-sort-control__text" id="sortEditText">{% trans 'edit layout' %}</span>
-              <span class="entity-sort-control__text"
-                    id="sortSaveText"
-                    style="display: none">{% trans 'save' %}</span>
-              <span class="icon-edit" id="sortEditIcon">
-                <i class="fa-solid fa-pencil"></i>
-              </span>
-              <span class="icon-save" id="sortSaveIcon" style="display: none;">
-                <i class="fa-regular fa-floppy-disk"></i>
-              </span>
+          </script>
+          {% if identity.user == request.user %}
+            <div class="entity-sort-control">
+              <div class="entity-sort-control__button" id="sortEditButton">
+                <span class="entity-sort-control__text" id="sortEditText">{% trans 'edit layout' %}</span>
+                <span class="entity-sort-control__text"
+                      id="sortSaveText"
+                      style="display: none">{% trans 'save' %}</span>
+                <span class="icon-edit" id="sortEditIcon">
+                  <i class="fa-solid fa-pencil"></i>
+                </span>
+                <span class="icon-save" id="sortSaveIcon" style="display: none;">
+                  <i class="fa-regular fa-floppy-disk"></i>
+                </span>
+              </div>
+              <div class="entity-sort-control__button"
+                   id="sortExitButton"
+                   style="display: none">
+                <span class="entity-sort-control__text">{% trans 'cancel' %}</span>
+              </div>
             </div>
-            <div class="entity-sort-control__button"
-                 id="sortExitButton"
+            <div class="entity-sort-control__button entity-sort-control__button--float-right"
+                 id="toggleDisplayButtonTemplate"
                  style="display: none">
-              <span class="entity-sort-control__text">{% trans 'cancel' %}</span>
+              <span class="showText" style="display: none;">{% trans 'show' %}</span>
+              <span class="hideText" style="display: none;">{% trans 'hide' %}</span>
             </div>
-          </div>
-          <div class="entity-sort-control__button entity-sort-control__button--float-right"
-               id="toggleDisplayButtonTemplate"
-               style="display: none">
-            <span class="showText" style="display: none;">{% trans 'show' %}</span>
-            <span class="hideText" style="display: none;">{% trans 'hide' %}</span>
-          </div>
-          <form action="{% url 'users:set_layout' %}" method="post" id="sortForm">
-            {% csrf_token %}
-            <input type="hidden" name="name" value="profile">
-            <input type="hidden" name="layout">
-          </form>
-          <script src="{{ cdn_url }}/npm/html5sortable@0.13.3/dist/html5sortable.min.js"></script>
-          <script src="{% static 'js/sort_layout.js' %}"></script>
+            <form action="{% url 'users:set_layout' %}" method="post" id="sortForm">
+              {% csrf_token %}
+              <input type="hidden" name="name" value="profile">
+              <input type="hidden" name="layout">
+            </form>
+            <script src="{{ cdn_url }}/npm/html5sortable@0.13.3/dist/html5sortable.min.js"></script>
+            <script src="{% static 'js/sort_layout.js' %}"></script>
+          {% endif %}
         {% endif %}
+        {# end feed_view else #}
       </div>
-      {% include "_sidebar.html" with show_progress=1 show_profile=1 %}
+      {% if feed_view %}
+        {% include "_sidebar.html" with show_profile=1 %}
+      {% else %}
+        {% include "_sidebar.html" with show_progress=1 show_profile=1 %}
+      {% endif %}
     </main>
     {% include "_footer.html" %}
     {% if identity.local and identity.user.mastodon %}

--- a/journal/templates/profile_posts.html
+++ b/journal/templates/profile_posts.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+{% load humanize %}
+{% load mastodon %}
+{% load thumb %}
+{% load user_actions %}
+{% load duration %}
+{% for post in posts %}
+  {% include "_event_post.html" %}
+  {% if forloop.last %}
+    <div class="htmx-indicator"
+         style="margin-left: 60px"
+         hx-get="{% url 'journal:profile_posts_data' user_name %}?last={{ post.pk }}"
+         hx-trigger="revealed"
+         hx-swap="outerHTML">
+      <i class="fa-solid fa-compact-disc fa-spin loading"></i>
+    </div>
+  {% endif %}
+{% empty %}
+  <div class="empty">
+    {% if request.GET.last %}
+      {% trans "nothing more." %}
+    {% else %}
+      {% trans "nothing so far." %}
+    {% endif %}
+  </div>
+{% endfor %}

--- a/journal/urls.py
+++ b/journal/urls.py
@@ -188,6 +188,11 @@ urlpatterns = [
         user_calendar_data,
         name="user_calendar_data",
     ),
+    re_path(
+        r"^users/(?P<user_name>[~A-Za-z0-9_\-.@]+)/profile/posts$",
+        profile_posts_data,
+        name="profile_posts_data",
+    ),
     path("users/<str:username>/feed/reviews/", ReviewFeed(), name="review_feed"),
     path("wrapped/", WrappedView.as_view(), name="wrapped_current_year"),
     path("wrapped/<int:year>/", WrappedView.as_view(), name="wrapped"),

--- a/journal/views/__init__.py
+++ b/journal/views/__init__.py
@@ -41,6 +41,7 @@ from .profile import (
     profile_collection_items,
     profile_created_collections,
     profile_liked_collections,
+    profile_posts_data,
     profile_shelf_items,
     user_calendar_data,
 )
@@ -99,6 +100,7 @@ __all__ = [
     "profile_collection_items",
     "profile_created_collections",
     "profile_liked_collections",
+    "profile_posts_data",
     "profile_shelf_items",
     "user_calendar_data",
     "ReviewFeed",

--- a/journal/views/profile.py
+++ b/journal/views/profile.py
@@ -16,7 +16,6 @@ from common.utils import (
     profile_identity_required,
     target_identity_required,
 )
-from takahe.models import Post
 from takahe.utils import Takahe
 from users.models import APIdentity
 
@@ -77,23 +76,26 @@ def profile(request: AuthedHttpRequest, user_name):
             {"identity": target, "redir": target.url},
         )
 
-    # anonymous user should not see real content unless permitted by user
     anonymous = not request.user.is_authenticated
-    if anonymous and (not target.local or not target.anonymous_viewable):
-        return render(
-            request,
-            "users/home_anonymous.html",
-            {
-                "identity": target,
-                "redir": f"/account/login?next={quote_plus(target.url)}",
-            },
-        )
+    if anonymous:
+        # anonymous user should not see remote user's content
+        if not target.local:
+            return redirect(target.profile_uri)
+        # anonymous user should not see local user's content unless permitted
+        elif not target.anonymous_viewable:
+            return render(
+                request,
+                "users/home_anonymous.html",
+                {
+                    "identity": target,
+                    "redir": f"/account/login?next={quote_plus(target.url)}",
+                },
+            )
 
     feed_view = not target.local and target.domain_name not in Takahe.get_neodb_peers(
         active_only=False
     )
     if feed_view:
-        top_tags = target.tag_manager.get_tags(public_only=True)[:10]
         return render(
             request,
             "profile.html",
@@ -218,20 +220,10 @@ def profile_posts_data(request: AuthedHttpRequest, user_name):
     target = request.target_identity
     last_pk = int_(request.GET.get("last", 0))
     viewer_pk = request.user.identity.pk
-    qs = Post.objects.exclude(state__in=["deleted", "deleted_fanned_out"]).filter(
-        author_id=target.pk
-    )
-    if Takahe.get_is_following(viewer_pk, target.pk):
-        qs = qs.exclude(visibility=3)
-    else:
-        qs = qs.filter(visibility__in=[0, 1, 4])
+    qs = Takahe.get_recent_posts(target.pk, viewer_pk, days=None)
     if last_pk:
         qs = qs.filter(pk__lt=last_pk)
-    posts = list(
-        qs.order_by("-pk")[:20]
-        .prefetch_related("attachments", "author")
-        .select_related("application")
-    )
+    posts = list(qs.order_by("-pk")[:20])
     prefetch_pieces_for_posts(posts)
     return render(
         request,

--- a/journal/views/profile.py
+++ b/journal/views/profile.py
@@ -9,12 +9,14 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_http_methods
 
 from catalog.models import *
+from common.models.misc import int_
 from common.utils import (
     AuthedHttpRequest,
     get_uuid_or_404,
     profile_identity_required,
     target_identity_required,
 )
+from takahe.models import Post
 from takahe.utils import Takahe
 from users.models import APIdentity
 
@@ -84,6 +86,30 @@ def profile(request: AuthedHttpRequest, user_name):
             {
                 "identity": target,
                 "redir": f"/account/login?next={quote_plus(target.url)}",
+            },
+        )
+
+    feed_view = not target.local and target.domain_name not in Takahe.get_neodb_peers(
+        active_only=False
+    )
+    if feed_view:
+        top_tags = target.tag_manager.get_tags(public_only=True)[:10]
+        return render(
+            request,
+            "profile.html",
+            {
+                "user": target.user,
+                "identity": target,
+                "me": False,
+                "top_tags": None,
+                "recent_posts": None,
+                "feed_view": True,
+                "shelf_list": {},
+                "collections_count": 0,
+                "pinned_collections": [],
+                "liked_collections_count": 0,
+                "layout": [],
+                "year": None,
             },
         )
 
@@ -182,6 +208,35 @@ def profile(request: AuthedHttpRequest, user_name):
             "layout": layout,
             "year": year,
         },
+    )
+
+
+@require_http_methods(["GET"])
+@login_required
+@profile_identity_required
+def profile_posts_data(request: AuthedHttpRequest, user_name):
+    target = request.target_identity
+    last_pk = int_(request.GET.get("last", 0))
+    viewer_pk = request.user.identity.pk
+    qs = Post.objects.exclude(state__in=["deleted", "deleted_fanned_out"]).filter(
+        author_id=target.pk
+    )
+    if Takahe.get_is_following(viewer_pk, target.pk):
+        qs = qs.exclude(visibility=3)
+    else:
+        qs = qs.filter(visibility__in=[0, 1, 4])
+    if last_pk:
+        qs = qs.filter(pk__lt=last_pk)
+    posts = list(
+        qs.order_by("-pk")[:20]
+        .prefetch_related("attachments", "author")
+        .select_related("application")
+    )
+    prefetch_pieces_for_posts(posts)
+    return render(
+        request,
+        "profile_posts.html",
+        {"posts": posts, "user_name": user_name},
     )
 
 

--- a/takahe/utils.py
+++ b/takahe/utils.py
@@ -842,14 +842,18 @@ class Takahe:
         )
 
     @staticmethod
-    def get_recent_posts(author_pk: int, viewer_pk: int | None = None):
-        since = timezone.now() - timedelta(days=90)
-        qs = (
-            Post.objects.exclude(state__in=["deleted", "deleted_fanned_out"])
-            .filter(author_id=author_pk)
-            .filter(published__gte=since)
-            .order_by("-published")
+    def get_recent_posts(
+        author_pk: int,
+        viewer_pk: int | None = None,
+        days: int | None = 90,
+    ):
+        qs = Post.objects.exclude(state__in=["deleted", "deleted_fanned_out"]).filter(
+            author_id=author_pk
         )
+        if days is not None:
+            since = timezone.now() - timedelta(days=days)
+            qs = qs.filter(published__gte=since)
+        qs = qs.order_by("-published")
         if viewer_pk and Takahe.get_is_following(viewer_pk, author_pk):
             qs = qs.exclude(visibility=3)
         else:


### PR DESCRIPTION
## Summary

- When a remote user's server is not in the neodb peer list (active or inactive), their profile page now shows a post feed instead of the empty shelf layout
- Posts auto-load via HTMX infinite scroll, matching the timeline page behavior
- No 90-day date limit applied to post fetching for this view (added optional `days` param to `Takahe.get_recent_posts`)
- Sidebar hides "Recent Posts" and "Current Targets" sections for this view

## Test plan

- [ ] Visit a remote non-neodb user profile (e.g. a mastodon.social user) — main area shows their posts with infinite scroll
- [ ] Scroll to bottom — next page of posts loads automatically
- [ ] Visit a remote neodb peer user profile — existing shelf layout unchanged
- [ ] Visit a local user profile — no change
- [ ] Unauthenticated users are still redirected to login for remote profiles