### PR TITLE
fix discover page excluding wrong identities from popular posts

### DIFF
--- a/catalog/jobs/discover.py
+++ b/catalog/jobs/discover.py
@@ -34,7 +34,7 @@ class DiscoverGenerator(BaseJob):
 
     def get_no_discover_identities(self):
         return list(
-            Identity.objects.exclude(discoverable=False).values_list("pk", flat=True)
+            Identity.objects.filter(discoverable=False).values_list("pk", flat=True)
         )
 
     def get_popular_posts(


### PR DESCRIPTION
## Summary

- `get_no_discover_identities()` incorrectly used `exclude(discoverable=False)`, which returned *discoverable* identities rather than the opted-out ones
- This caused reviews from opted-in users to be excluded from the discover feed, and also generated a cross-database subquery (`users_identity` table from Takahe's DB) when the result was inadvertently a QuerySet
- Fixed by changing to `filter(discoverable=False)` to match the original `Takahe.get_no_discover_identities()` behavior

Fixes NEODB-SOCIAL-4FJ

## Test plan

- [ ] Verify discover page shows popular posts without errors in rqworker logs
- [ ] Confirm `DiscoverGenerator` runs without `ProgrammingError: relation "users_identity" does not exist`